### PR TITLE
Add libs.versions.toml to the change list of source code

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,6 +41,7 @@ jobs:
               - '${{ matrix.design-pattern }}/src/**'
               - '${{ matrix.design-pattern }}/build.gradle.kts'
               - 'build.gradle.kts'
+              - 'gradle/libs.versions.toml'
               - 'settings.gradle.kts'
               - 'gradle.properties'
             docs:


### PR DESCRIPTION
Ensure that CI is running whenever renovate updates a dependency.