### PR TITLE
Extract design patterns matrix to another file

### DIFF
--- a/.github/workflows/matrix-template.yml
+++ b/.github/workflows/matrix-template.yml
@@ -1,0 +1,6 @@
+strategy:
+  matrix:
+    design-pattern: [
+      "singleton",
+      "factory-method"
+    ]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,10 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        design-pattern: [
-          "singleton",
-          "factory-method"
-        ]
+        include:
+          - <<: *{{ matrix-template.yml }}
     steps:
 
       - name: Git Checkout


### PR DESCRIPTION
This commit extracts the design patterns matrix from the `pull_request` workflow, so it can be reused, and adding a new pattern will not trigger the `pull_request` workflow for all other patterns