### PR TITLE
Separate build and linter pipelines

### DIFF
--- a/.github/workflows/markdown_linter.yml
+++ b/.github/workflows/markdown_linter.yml
@@ -1,0 +1,98 @@
+name: markdown-linter
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdown-linter:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        design-pattern: [
+          "abstract-factory",
+          "adapter",
+          "bridge",
+          "builder",
+          "chain-of-responsibility",
+          "command",
+          "composite",
+          "decorator",
+          "facade",
+          "factory-method",
+          "flyweight",
+          "iterator",
+          "mediator",
+          "observer",
+          "prototype",
+          "proxy",
+          "singleton",
+          "state",
+          "static-factory-method",
+          "strategy",
+          "template-method",
+          "visitor",
+        ]
+    steps:
+
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for Changes
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          filters: |
+            docs:
+              - '${{ matrix.design-pattern }}/README.md'
+
+      - name: Lint README
+        if: steps.changes.outputs.docs == 'true'
+        uses: avto-dev/markdown-lint@v1
+        env:
+          DESIGN_PATTERN: ${{ matrix.design-pattern }}
+        with:
+          config: './config/markdown-lint/rules.json'
+          args: '${DESIGN_PATTERN}/README.md'
+
+  main-markdown-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for Changes
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'README.md'
+
+      - name: Lint README
+        if: steps.changes.outputs.docs == 'true'
+        uses: avto-dev/markdown-lint@v1
+        with:
+          config: './config/markdown-lint/rules.json'
+          args: 'README.md'
+
+  markdown-linter-check:
+    if: always()
+    needs:
+      - markdown-linter
+      - main-markdown-linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all Markdown linter jobs are succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,25 +59,25 @@ jobs:
         with:
           filters: |
             source_code:
-              - '.github/workflows/**'
-              - '${{ matrix.design-pattern }}/src/**'
               - '${{ matrix.design-pattern }}/build.gradle.kts'
+              - '${{ matrix.design-pattern }}/src/**'
+              - '.github/workflows/**'
               - 'build.gradle.kts'
               - 'gradle/libs.versions.toml'
               - 'settings.gradle.kts'
-              - 'gradle.properties'
-            docs:
-              - '${{ matrix.design-pattern }}/README.md'
-              - README.md
+            diagrams:
+              - '${{ matrix.design-pattern }}/etc/*.puml'
 
-      - name: Lint README
-        if: steps.changes.outputs.docs == 'true'
-        uses: avto-dev/markdown-lint@v1
-        env:
-          DESIGN_PATTERN: ${{ matrix.design-pattern }}
-        with:
-          config: './config/markdown-lint/rules.json'
-          args: '${DESIGN_PATTERN}/README.md'
+      - name: Generate PlantUML Diagram
+        if: steps.changes.outputs.diagrams == 'true'
+        run: |
+          ./gradlew ${{ matrix.design-pattern }}:plantumlAll
+          
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add .
+          git commit -m "Update PlantUML diagrams for ${{ matrix.design-pattern }}"
+          git push
 
       - name: Gradle Build
         if: steps.changes.outputs.source_code == 'true'


### PR DESCRIPTION
This commit split the build and linting pipelines so when a change is made for the README file no need for a wait for the Grale build to finish exists.