### PR TITLE
[Bugfix] Spotless apply doesn't work from the root

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.spotless) apply true
     alias(libs.plugins.plantuml) apply true
+    alias(libs.plugins.kotlin.jvm) apply true
 }
 
 allprojects {


### PR DESCRIPTION
This commit fixes a bug that causes Spotless to not be able to run when running on the root project because of a missing usage of the Kotlin plugin for Kotlin code compilation