### PR TITLE
Simplify logger structure

### DIFF
--- a/abstract-factory/src/main/kotlin/com/yonatankarp/abstractfactory/App.kt
+++ b/abstract-factory/src/main/kotlin/com/yonatankarp/abstractfactory/App.kt
@@ -4,8 +4,11 @@ import com.yonatankarp.abstractfactory.Kingdom.FactoryMaker.KingdomType
 import com.yonatankarp.abstractfactory.Kingdom.FactoryMaker.makeFactory
 import org.slf4j.LoggerFactory
 
-private val logger = LoggerFactory.getLogger("com.yonatankarp.abstractfactory")
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.abstractfactory")
 
+/**
+ * Program main entry point.
+ */
 fun main() {
     logger.info("elf kingdom")
     val elfKingdom = createKingdom(KingdomType.ELF)

--- a/adapter/src/main/kotlin/com/yonatankarp/adapter/App.kt
+++ b/adapter/src/main/kotlin/com/yonatankarp/adapter/App.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.adapter
 
+import org.slf4j.LoggerFactory
+
 /**
  * An adapter helps two incompatible interfaces to work together. This is the
  * real world definition for an adapter. Interfaces may be incompatible but the
@@ -23,6 +25,12 @@ package com.yonatankarp.adapter
  * {@link FishingBoat}. The captain needs a rowing boat which he can operate.
  * The spec is in {@link RowingBoat}. We will use the Adapter pattern to reuse
  * {@link FishingBoat}.
+ */
+
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.adapter")
+
+/**
+ * Program main entry point.
  */
 fun main() {
     // The captain can only operate rowing boats but with adapter he is able to

--- a/adapter/src/main/kotlin/com/yonatankarp/adapter/FishingBoat.kt
+++ b/adapter/src/main/kotlin/com/yonatankarp/adapter/FishingBoat.kt
@@ -1,7 +1,5 @@
 package com.yonatankarp.adapter
 
-import org.slf4j.LoggerFactory
-
 /**
  * Device class (adaptee in the pattern). We want to reuse this class. Fishing
  * boat moves by sailing.
@@ -9,9 +7,5 @@ import org.slf4j.LoggerFactory
 internal class FishingBoat {
     fun sail() {
         logger.info("The fishing boat is sailing")
-    }
-
-    companion object {
-        private val logger = LoggerFactory.getLogger(FishingBoat::class.java)
     }
 }

--- a/adapter/src/main/kotlin/com/yonatankarp/adapter/FishingBoatAdapter.kt
+++ b/adapter/src/main/kotlin/com/yonatankarp/adapter/FishingBoatAdapter.kt
@@ -1,7 +1,5 @@
 package com.yonatankarp.adapter
 
-import org.slf4j.LoggerFactory
-
 /**
  * Adapter class. Adapts the interface of the device ([FishingBoat]) into
  * [RowingBoat] interface expected by the client ([Captain]).
@@ -10,9 +8,5 @@ internal class FishingBoatAdapter(private val boat: FishingBoat) : RowingBoat {
     override fun row() {
         logger.info("Using class adapter")
         boat.sail()
-    }
-
-    companion object {
-        private val logger = LoggerFactory.getLogger(FishingBoatAdapter::class.java)
     }
 }

--- a/adapter/src/main/kotlin/com/yonatankarp/adapter/FishingBoatExtFunctionAdapter.kt
+++ b/adapter/src/main/kotlin/com/yonatankarp/adapter/FishingBoatExtFunctionAdapter.kt
@@ -1,9 +1,5 @@
 package com.yonatankarp.adapter
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger("com.yonatankarp.adapter.FishingBoat.toRowingBoat")
-
 internal fun FishingBoat.toRowingBoat(): RowingBoat = object : RowingBoat {
     override fun row() {
         logger.info("Using extension function adapter")

--- a/builder/src/main/kotlin/com/yonatankarp/builder/App.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/App.kt
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory
  * default values for unset arguments</p>
  */
 
-private val logger = LoggerFactory.getLogger("com.yonatankarp.builder")
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.builder")
 
 /**
  * Program entry point.

--- a/decorator/src/main/kotlin/com/yonatankarp/decorator/App.kt
+++ b/decorator/src/main/kotlin/com/yonatankarp/decorator/App.kt
@@ -13,9 +13,12 @@ import org.slf4j.LoggerFactory
  * and perform the attack again. You can see how the behavior changes after the
  * decoration.
  */
-fun main() {
-    val logger = LoggerFactory.getLogger("com.yonatankarp.decorator")
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.decorator")
 
+/**
+ * Program main entry point.
+ */
+fun main() {
     // simple troll
     logger.info("A simple looking troll approaches.")
     val troll = SimpleTroll()

--- a/decorator/src/main/kotlin/com/yonatankarp/decorator/ClubbedTroll.kt
+++ b/decorator/src/main/kotlin/com/yonatankarp/decorator/ClubbedTroll.kt
@@ -20,7 +20,6 @@ class ClubbedTroll(private val decorated: Troll) : Troll {
 
     companion object {
         private val logger = LoggerFactory.getLogger(ClubbedTroll::class.java)
-
         private const val CLUB_ATTACK_POWER = 10
     }
 }

--- a/decorator/src/main/kotlin/com/yonatankarp/decorator/SimpleTroll.kt
+++ b/decorator/src/main/kotlin/com/yonatankarp/decorator/SimpleTroll.kt
@@ -18,7 +18,6 @@ class SimpleTroll : Troll {
 
     companion object {
         private val logger = LoggerFactory.getLogger(SimpleTroll::class.java)
-
         private const val ATTACK_POWER = 10
     }
 }

--- a/factory-method/src/main/kotlin/com/yonatankarp/factory/method/App.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factory/method/App.kt
@@ -3,7 +3,7 @@ package com.yonatankarp.factory.method
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-private val logger: Logger = LoggerFactory.getLogger("com.yonatankarp.factory.method")
+internal val logger: Logger = LoggerFactory.getLogger("com.yonatankarp.factory.method")
 
 /**
  * Program entry point.

--- a/factory/src/main/kotlin/com/yonatankarp/factory/App.kt
+++ b/factory/src/main/kotlin/com/yonatankarp/factory/App.kt
@@ -2,7 +2,7 @@ package com.yonatankarp.factory
 
 import org.slf4j.LoggerFactory
 
-private val logger = LoggerFactory.getLogger("com.yonatankarp.factory")
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.factory")
 
 /**
  * Program main entry point.

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/App.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/App.kt
@@ -15,9 +15,13 @@ import org.slf4j.LoggerFactory
  * by cloning the existing ones. The factory's prototype objects are given as
  * constructor parameters.
  */
-fun main() {
-    val logger = LoggerFactory.getLogger("com.yonatankarp.prototype")
 
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.prototype")
+
+/**
+ * Program main entry point.
+ */
+fun main() {
     val elfFactory = HeroFactory(
         ElfMage("cooking"),
         ElfWarlord("cleaning"),

--- a/singleton/src/main/kotlin/com/yonatankarp/singleton/App.kt
+++ b/singleton/src/main/kotlin/com/yonatankarp/singleton/App.kt
@@ -16,11 +16,12 @@ import org.slf4j.LoggerFactory
  *
  * Fortunately, Kotlin comes with a built-in implementation for Singletons using
  * the `object` keyword.
- *
- * @author: yonatankarp
  */
-val logger: Logger = LoggerFactory.getLogger("com.yonatankarp.singleton")
+internal val logger: Logger = LoggerFactory.getLogger("com.yonatankarp.singleton")
 
+/**
+ * Program main entry point.
+ */
 fun main() {
     val ivoryTower1 = IvoryTower
     val ivoryTower2 = IvoryTower


### PR DESCRIPTION
This commit simplifies the logger structure of each pattern by having a single logger instance with the package name of the pattern which lives in the `App.kt` file of each pattern and has the `internal` exposure level. Hence, only classes within the pattern package can use it, and everything logged in the pattern appears with the same prefix which makes it easier to read.
