### PR TITLE
Add gradle wrapper pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ registries:
     type: maven-repository
     url: https://maven.pkg.github.com/yonatankarp/kotlin-junit-tools
     username: ${{ env.GITHUB_ACTOR }}
-    password: ${{ secrets.GITHUB_PAT }}
+    password: ${{ secrets.CI_PAT }}
 
 updates:
   # Maintain dependencies for GitHub Actions

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -92,7 +92,9 @@ jobs:
         run: ./gradlew ${{ matrix.design-pattern }}:spotlessCheck ${{ matrix.design-pattern }}:build
 
   ci-check:
-    if: always()
+    if: |
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     needs:
       - ci
     runs-on: ubuntu-latest
@@ -121,7 +123,7 @@ jobs:
         run: gh pr review --approve "$PR_URL" && sleep 5
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.CI_PAT }}
 
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
@@ -129,4 +131,4 @@ jobs:
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.CI_PAT }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,28 @@
+name: Update Gradle Wrapper
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          repo-token: ${{ secrets.CI_PAT` }}


### PR DESCRIPTION
This commit adds the Gradle upgrade pipeline that would run once a day at midnight and check for a new version of Gradle. If such a version exists it would open a new PR with the required changes.
