### PR TITLE
[Bug] Add CI check step back

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,20 @@ jobs:
     uses: yonatankarp/github-actions/.github/workflows/ci.yml@v1
     with:
       context: ${{ matrix.module }}
-      build_docker: false
+      build_dockerfile: false
+
+  ci-check:
+    if: |
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    needs:
+      - pipeline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all CI jobs are succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
 
   dependabot_auto_merge:
     needs: pipeline


### PR DESCRIPTION
This commit reintroduces the ci-check step that validates that all the different patterns have successfully passed CI. It was mistakenly removed during the migration to the remote actions


Pull request title

- Clearly and concisely describes what it does
- Refer to the issue that it solves, if available


Pull request description

- Describes the main changes that come with the pull request
- Any relevant additional information is provided
