### PR TITLE
Standardize package naming convention

### DIFF
--- a/chain-of-responsibility/etc/chain-of-responsibility.puml
+++ b/chain-of-responsibility/etc/chain-of-responsibility.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.chainofresponsibility {
   class App {
     + main(args : String[]) {static}
   }

--- a/command/etc/command.puml
+++ b/command/etc/command.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.command {
   class App {
     + main(args : String[]) {static}
   }

--- a/factory-method/etc/factory-method.puml
+++ b/factory-method/etc/factory-method.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.factorymethod {
   class App {
     - LOGGER : Logger {static}
     - blacksmith : Blacksmith

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/App.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/App.kt
@@ -1,9 +1,9 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-internal val logger: Logger = LoggerFactory.getLogger("com.yonatankarp.factory.method")
+internal val logger: Logger = LoggerFactory.getLogger("com.yonatankarp.factorymethod")
 
 /**
  * Program entry point.

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/Blacksmith.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/Blacksmith.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 /**
  * The interface containing method for producing objects.

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/ElfBlacksmith.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/ElfBlacksmith.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 /**
  * Concrete subclass for creating new objects.

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/ElfWeapon.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/ElfWeapon.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 /**
  * ElfWeapon.

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/OrcBlacksmith.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/OrcBlacksmith.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 /**
  * Concrete subclass for creating new objects.

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/OrcWeapon.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/OrcWeapon.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 internal class OrcWeapon(override val weaponType: WeaponType) : Weapon {
     override fun toString() = "an orcish $weaponType"

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/Weapon.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/Weapon.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 /**
  * Weapon interface.

--- a/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/WeaponType.kt
+++ b/factory-method/src/main/kotlin/com/yonatankarp/factorymethod/WeaponType.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 /**
  * WeaponType enumeration.

--- a/factory-method/src/test/kotlin/com/yonatankarp/factorymethod/AppTest.kt
+++ b/factory-method/src/test/kotlin/com/yonatankarp/factorymethod/AppTest.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow

--- a/factory-method/src/test/kotlin/com/yonatankarp/factorymethod/FactoryMethodTest.kt
+++ b/factory-method/src/test/kotlin/com/yonatankarp/factorymethod/FactoryMethodTest.kt
@@ -1,4 +1,4 @@
-package com.yonatankarp.factory.method
+package com.yonatankarp.factorymethod
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/iterator/etc/iterator.puml
+++ b/iterator/etc/iterator.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.iterator {
   class App {
     + main(args : String[]) {static}
   }

--- a/mediator/etc/mediator.puml
+++ b/mediator/etc/mediator.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.mediator {
   class App {
     + main(args : String[]) {static}
   }

--- a/memento/etc/memento.puml
+++ b/memento/etc/memento.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.memento {
   class App {
     + main(args : String[]) {static}
   }

--- a/observer/etc/observer.puml
+++ b/observer/etc/observer.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.observer {
   class App {
     + main(args : String[]) {static}
   }

--- a/state/etc/state.puml
+++ b/state/etc/state.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.state {
   class App {
     - LOGGER : Logger {static}
     - blacksmith : Blacksmith

--- a/template-method/etc/template-method.puml
+++ b/template-method/etc/template-method.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.templatemethod {
   class App {
     + main(args : String[]) {static}
   }

--- a/visitor/etc/visitor.puml
+++ b/visitor/etc/visitor.puml
@@ -1,5 +1,5 @@
 @startuml
-package com.yonatankarp.factory.method {
+package com.yonatankarp.visitor {
   class App {
     + main(args : String[]) {static}
   }


### PR DESCRIPTION
- Rename factory-method package from `com.yonatankarp.factory.method` to `com.yonatankarp.factorymethod` to match all other modules
- Fix PlantUML diagrams in 9 modules (chain-of-responsibility, command, iterator, mediator, memento, observer, state, template-method, visitor) that incorrectly referenced `com.yonatankarp.factory.method` instead of their own package