### PR TITLE
Align singleton pattern with project standards

### DIFF
--- a/singleton/README.md
+++ b/singleton/README.md
@@ -4,44 +4,69 @@ category: Creational
 language: en
 tag:
   - Gang of Four
+  - Instantiation
+  - Lazy initialization
+  - Resource management
 ---
+
+## Also known as
+
+- Single Instance
 
 ## Intent
 
-Ensure a class only has one instance, and provide a global point of access to
-it.
+Ensure a class only has one instance, and provide a global
+point of access to it.
 
 ## Explanation
 
-Real-world example
+### Real-world example
 
-> There can only be one ivory tower where the wizards study their magic. The
-> same enchanted ivory tower is always used by the wizards. The ivory tower
-> here is a singleton.
+> There can only be one ivory tower where the wizards study
+> their magic. The same enchanted ivory tower is always used
+> by the wizards. The ivory tower here is a singleton.
 
-In plain words
+### In plain words
 
-> Ensures that only one object of a particular class is ever created.
+> Ensures that only one object of a particular class is ever
+> created.
 
-Wikipedia says
+### Wikipedia says
 
-> In software engineering, the singleton pattern is a software design pattern
-> that restricts the instantiation of a class to one object. This is useful
-> when exactly one object is needed to coordinate actions across the system.
+> In software engineering, the singleton pattern is a
+> software design pattern that restricts the instantiation
+> of a class to one object. This is useful when exactly one
+> object is needed to coordinate actions across the system.
 
-### Programmatic Example
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant Singleton
+    participant ClientB
+    ClientA->>Singleton: getInstance()
+    ClientB->>Singleton: getInstance()
+    Singleton-->>ClientA: Return same instance
+    Singleton-->>ClientB: Return same instance
+    ClientA->>Singleton: call operation()
+    ClientB->>Singleton: call operation()
+```
 
-Kotlin makes it externally easy to create singletons by introducing the language
-keyword `object`. By using this keyword we will get from the compiler an
-implementation of the Singleton pattern, that contains all of our requirements.
+### **Programmatic Example**
+
+Kotlin makes it externally easy to create singletons by
+introducing the language keyword `object`. By using this
+keyword we will get from the compiler an implementation of
+the Singleton pattern, that contains all of our
+requirements.
 
 ```kotlin
 data object IvoryTower
 ```
 
-One of the key differences between a `class` and a `object` is that the latter
-does not allow constructor arguments. If your implementation needs
-initialization for your Singleton (e.g. to load data) you can use an `init`
+One of the key differences between a `class` and an
+`object` is that the latter does not allow constructor
+arguments. If your implementation needs initialization for
+your Singleton (e.g. to load data) you can use an `init`
 block.
 
 ```kotlin
@@ -52,8 +77,9 @@ data object IvoryTower {
 }
 ```
 
-Note that if the Singleton object is never invoked, it won't run its
-initialization block at all. This is called lazy initialization.
+Note that if the Singleton object is never invoked, it
+won't run its initialization block at all. This is called
+lazy initialization.
 
 Then in order to use:
 
@@ -66,35 +92,32 @@ logger.info("ivoryTower2={}", ivoryTower2)
 
 The output on console:
 
-```console
-09:21:31.107 [main] INFO Singlton -- Initializing Ivory Tower...
-09:21:31.109 [main] INFO Singlton -- ivoryTower1=com.yonatankarp.singleton.IvoryTower@1207938418
-09:21:31.111 [main] INFO Singlton -- ivoryTower2=com.yonatankarp.singleton.IvoryTower@1207938418
+```text
+09:21:31.107 [main] INFO Singleton -- Initializing Ivory Tower...
+09:21:31.109 [main] INFO Singleton -- ivoryTower1=com.yonatankarp.singleton.IvoryTower@1207938418
+09:21:31.111 [main] INFO Singleton -- ivoryTower2=com.yonatankarp.singleton.IvoryTower@1207938418
 ```
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    class App {
-        -Logger LOGGER$
-        +App()
-        +main(args String[])$
-    }
     class IvoryTower {
         <<data object>>
+        +toString() String
     }
-    App --> IvoryTower : uses
 ```
 
 ## Applicability
 
 Use the Singleton pattern when
 
-- There must be exactly one instance of a class, and it must be accessible to
-  clients from a well-known access point
-- When the sole instance should be extensible by subclassing, and clients should
-  be able to use an extended instance without modifying their code
+- There must be exactly one instance of a class, and it
+  must be accessible to clients from a well-known access
+  point
+- When the sole instance should be extensible by
+  subclassing, and clients should be able to use an
+  extended instance without modifying their code
 
 Some typical use cases for the Singleton
 
@@ -104,12 +127,13 @@ Some typical use cases for the Singleton
 
 ## Consequences
 
-- Violates Single Responsibility Principle (SRP) by controlling their creation
-  and lifecycle.
-- Encourages using a globally shared instance which prevents an object and
-  resources used by this object from being deallocated.
-- Creates tightly coupled code. The clients of the Singleton become difficult
-  to test.
+- Violates Single Responsibility Principle (SRP) by
+  controlling their creation and lifecycle.
+- Encourages using a globally shared instance which
+  prevents an object and resources used by this object
+  from being deallocated.
+- Creates tightly coupled code. The clients of the
+  Singleton become difficult to test.
 - Makes it almost impossible to subclass a Singleton.
 
 ## Credits

--- a/singleton/src/main/kotlin/com/yonatankarp/singleton/IvoryTower.kt
+++ b/singleton/src/main/kotlin/com/yonatankarp/singleton/IvoryTower.kt
@@ -1,9 +1,10 @@
 package com.yonatankarp.singleton
 
 /**
- * Singleton class. Eagerly initialized static instance guarantees thread safety.
- *
- * @author yonatankarp
+ * [IvoryTower] is a singleton implemented via Kotlin's `object`
+ * keyword, which guarantees a single, thread-safe instance without
+ * the boilerplate required in Java (private constructor, static
+ * field, double-checked locking, etc.).
  */
 data object IvoryTower {
     init {

--- a/singleton/src/test/kotlin/com/yonatankarp/singleton/IvoryTowerTest.kt
+++ b/singleton/src/test/kotlin/com/yonatankarp/singleton/IvoryTowerTest.kt
@@ -20,12 +20,14 @@ internal class IvoryTowerTest {
      */
     @Test
     fun `test multiple calls return the same object in the same thread`() {
-        // Create several instances in the same calling thread
+        // Given
         val instance1 = IvoryTower
+
+        // When
         val instance2 = IvoryTower
         val instance3 = IvoryTower
 
-        // now check they are equal
+        // Then
         assertSame(instance1, instance2)
         assertSame(instance1, instance3)
         assertSame(instance2, instance3)
@@ -38,21 +40,19 @@ internal class IvoryTowerTest {
     fun `test multiple calls return the same object in different threads`() =
         runTest {
             assertTimeout(Duration.ofMillis(10000)) {
-                // Create 10,000 tasks and inside each callable instantiate the
-                // singleton class
+                // Given
                 val tasks =
                     (0..10_000)
                         .map { { IvoryTower } }
                         .toList()
-
-                // wait for all the threads to complete
                 val expectedInstance = IvoryTower
 
-                // Create 10,000 calls to get the singleton instance from
-                // separate coroutines concurrently
+                // When
                 tasks.forEach { task ->
                     launch(Dispatchers.Default) {
                         val instance = task()
+
+                        // Then
                         assertNotNull(instance)
                         assertSame(expectedInstance, instance)
                     }


### PR DESCRIPTION
Align singleton pattern with project standards

- Remove `@author` tag from `IvoryTower.kt` and improve KDoc
  to reference `[IvoryTower]` and mention Kotlin `object` keyword
- Add `// Given // When // Then` comments to test bodies
- Fix README: add missing frontmatter tags (`Instantiation`,
  `Lazy initialization`, `Resource management`), add
  `Also known as` section, fix sub-header levels to `###`,
  bold `Programmatic Example`, add Mermaid sequence diagram,
  fix `console` to `text` code fence, fix class diagram to
  remove Java-style `App` class, fix "Singlton" typo, wrap
  prose lines to <= 80 chars

Related to #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with additional tags, "Also known as" section, and visual sequence diagram illustrating singleton behavior
  * Added "Wikipedia says" section and restructured content with blockquote formatting
  * Reformatted code examples and corrected output labels
  * Updated implementation documentation for clarity

* **Tests**
  * Reorganized test comments for improved readability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->