### PR TITLE
Align strategy pattern with project standards

### DIFF
--- a/strategy/README.md
+++ b/strategy/README.md
@@ -3,7 +3,11 @@ title: Strategy
 category: Behavioral
 language: en
 tag:
- - Gang of Four
+  - Decoupling
+  - Extensibility
+  - Gang of Four
+  - Interface
+  - Polymorphism
 ---
 
 ## Also known as
@@ -12,69 +16,82 @@ tag:
 
 ## Intent
 
-Define a family of algorithms, encapsulate each one, and make them
-interchangeable. Strategy lets the algorithm vary independently of the clients
-that use it.
+Define a family of algorithms, encapsulate each one,
+and make them interchangeable. Strategy lets the
+algorithm vary independently of the clients that use it.
 
 ## Explanation
 
-Real-world example
+### Real-world example
 
-> Slaying dragons is a dangerous job. With experience, it becomes easier.
-> Veteran dragonslayers have developed different fighting strategies against
-> different types of dragons.
+> Slaying dragons is a dangerous job. With experience,
+> it becomes easier. Veteran dragonslayers have developed
+> different fighting strategies against different types
+> of dragons.
 
-In plain words
+### In plain words
 
-> Strategy pattern allows choosing the best-suited algorithm at runtime.
-
-Wikipedia says
-
-> In computer programming, the strategy pattern (also known as the policy
-> pattern) is a behavioral software design pattern that enables selecting an
+> Strategy pattern allows choosing the best-suited
 > algorithm at runtime.
 
-### Programmatic Example
+### Wikipedia says
 
-Let's first introduce the dragon-slaying strategy interface and its
-implementations.
+> In computer programming, the strategy pattern (also
+> known as the policy pattern) is a behavioral software
+> design pattern that enables selecting an algorithm at
+> runtime.
+
+### **Programmatic Example**
+
+Let's first introduce the dragon-slaying strategy
+interface and its implementations.
 
 ```kotlin
 fun interface DragonSlayingStrategy {
-  fun execute()
+    fun execute()
 }
 
-class MeleeStrategy : DragonSlayingStrategy {
+internal class MeleeStrategy : DragonSlayingStrategy {
     override fun execute() {
-        logger.info("With your Excalibur you sever the dragon's head!")
+        logger.info(
+            "With your Excalibur you sever the dragon's head!"
+        )
     }
 }
 
-class ProjectileStrategy : DragonSlayingStrategy {
-  override fun execute() {
-    logger.info("You shoot the dragon with the magical crossbow and it falls dead on the ground!")
-  }
+internal class ProjectileStrategy : DragonSlayingStrategy {
+    override fun execute() {
+        logger.info(
+            "You shoot the dragon with the magical crossbow"
+                + " and it falls dead on the ground!"
+        )
+    }
 }
 
-class SpellStrategy : DragonSlayingStrategy {
-  override fun execute() {
-    logger.info("You cast the spell of disintegration and the dragon vaporizes in a pile of dust!")
-  }
+internal class SpellStrategy : DragonSlayingStrategy {
+    override fun execute() {
+        logger.info(
+            "You cast the spell of disintegration"
+                + " and the dragon vaporizes in a pile of dust!"
+        )
+    }
 }
 ```
 
-And here is the mighty dragonslayer, who can pick his fighting strategy based on
-the opponent.
+And here is the mighty `DragonSlayer`, who can pick
+his fighting strategy based on the opponent.
 
 ```kotlin
-class DragonSlayer(private var strategy: DragonSlayingStrategy) {
-  fun changeStrategy(strategy: DragonSlayingStrategy) {
-    this.strategy = strategy
-  }
+internal class DragonSlayer(
+    private var strategy: DragonSlayingStrategy,
+) {
+    fun changeStrategy(strategy: DragonSlayingStrategy) {
+        this.strategy = strategy
+    }
 
-  fun goToBattle() {
-    strategy.execute()
-  }
+    fun goToBattle() {
+        strategy.execute()
+    }
 }
 ```
 
@@ -102,65 +119,73 @@ With your Excalibur you sever the dragon's head!
 Red dragon emerges.
 You shoot the dragon with the magical crossbow and it falls dead on the ground!
 Black dragon lands before you.
-You cast the spell of disintegration and the dragon vaporizes in a pile of dust!    
+You cast the spell of disintegration and the dragon vaporizes in a pile of dust!
 ```
 
-What's more, the lambda expressions in Kotlin provides another approach for the
-implementation:
+Because `DragonSlayingStrategy` is a `fun interface`,
+strategies can also be expressed as lambdas:
 
 ```kotlin
-class LambdaStrategy {
-  enum class Strategy(private val dragonSlayingStrategy: DragonSlayingStrategy) :
-    DragonSlayingStrategy {
-    MELEE_STRATEGY(
-      DragonSlayingStrategy {
-        logger.info("With your Excalibur you severe the dragon's head!")
-      }
-    ),
-    PROJECTILE_STRATEGY(
-      DragonSlayingStrategy {
-        logger.info("You shoot the dragon with the magical crossbow and it falls dead on the ground!")
-      }
-    ),
-    SPELL_STRATEGY(
-      DragonSlayingStrategy {
-        logger.info("You cast the spell of disintegration and the dragon vaporizes in a pile of dust!")
-      }
-    );
+val functionalDragonSlayer = DragonSlayer {
+    logger.info(
+        "With your Excalibur you sever the dragon's head!"
+    )
+}
+functionalDragonSlayer.goToBattle()
+```
 
-    override fun execute() {
-      dragonSlayingStrategy.execute()
+An enum-based variant delegates each entry to a
+`DragonSlayingStrategy` lambda:
+
+```kotlin
+internal class EnumStrategy {
+    internal enum class Strategy(
+        private val dragonSlayingStrategy: DragonSlayingStrategy,
+    ) : DragonSlayingStrategy {
+        MELEE_STRATEGY(
+            DragonSlayingStrategy {
+                logger.info(
+                    "With your Excalibur you sever"
+                        + " the dragon's head!"
+                )
+            }
+        ),
+        PROJECTILE_STRATEGY(
+            DragonSlayingStrategy {
+                logger.info(
+                    "You shoot the dragon with the magical"
+                        + " crossbow and it falls dead"
+                        + " on the ground!"
+                )
+            }
+        ),
+        SPELL_STRATEGY(
+            DragonSlayingStrategy {
+                logger.info(
+                    "You cast the spell of disintegration"
+                        + " and the dragon vaporizes"
+                        + " in a pile of dust!"
+                )
+            }
+        ),
+        ;
+
+        override fun execute() {
+            dragonSlayingStrategy.execute()
+        }
     }
-  }
 }
 ```
 
-And here's the dragonslayer in action.
+A fully functional approach uses a type alias and
+method references:
 
 ```kotlin
-logger.info(GREEN_DRAGON_SPOTTED)
-val enumDragonSlayer = DragonSlayer(MELEE_STRATEGY)
-enumDragonSlayer.goToBattle()
+internal typealias Strategy = () -> Unit
 
-logger.info(RED_DRAGON_EMERGES)
-enumDragonSlayer.changeStrategy(PROJECTILE_STRATEGY)
-enumDragonSlayer.goToBattle()
-
-logger.info(BLACK_DRAGON_LANDS)
-enumDragonSlayer.changeStrategy(SPELL_STRATEGY)
-enumDragonSlayer.goToBattle()
-```
-
-The program output is the same as the above one.
-
-Alternatively, a full functional approach can be used here. In such case the
-`DragonSlayer` would receive lambda function to execute that would be the
-strategy.
-
-```kotlin
-typealias Strategy = () -> Unit
-
-class DragonSlayer(private var strategy: Strategy) {
+internal class FunctionalDragonSlayer(
+    private var strategy: Strategy,
+) {
     fun changeStrategy(strategy: Strategy) {
         this.strategy = strategy
     }
@@ -169,53 +194,51 @@ class DragonSlayer(private var strategy: Strategy) {
         strategy()
     }
 }
-```
 
-The strategies would be defined as functions in the scope of an `object`:
-
-```kotlin
-object Strategy {
+internal object LambdaStrategy {
     fun meleeStrategy() =
-        logger.info("With your Excalibur you sever the dragon's head!")
+        logger.info(
+            "With your Excalibur you sever the dragon's head!"
+        )
 
     fun projectileStrategy() =
-        logger.info("You shoot the dragon with the magical crossbow and it falls dead on the ground!")
+        logger.info(
+            "You shoot the dragon with the magical crossbow"
+                + " and it falls dead on the ground!"
+        )
 
     fun spellStrategy() =
-        logger.info("You cast the spell of disintegration and the dragon vaporizes in a pile of dust!")
+        logger.info(
+            "You cast the spell of disintegration"
+                + " and the dragon vaporizes in a pile of dust!"
+        )
 }
 ```
 
-And here's the dragonslayer in action.
-
 ```kotlin
-logger.info(GREEN_DRAGON_SPOTTED)
-val dragonSlayer = DragonSlayer(Strategy::meleeStrategy)
-dragonSlayer.goToBattle()
+val lambdaDragonSlayer =
+    FunctionalDragonSlayer(LambdaStrategy::meleeStrategy)
+lambdaDragonSlayer.goToBattle()
 
-logger.info(RED_DRAGON_EMERGES)
-dragonSlayer.changeStrategy(Strategy::projectileStrategy)
-dragonSlayer.goToBattle()
-
-logger.info(BLACK_DRAGON_LANDS)
-dragonSlayer.changeStrategy(Strategy::spellStrategy)
-dragonSlayer.goToBattle()
+lambdaDragonSlayer.changeStrategy(
+    LambdaStrategy::projectileStrategy
+)
+lambdaDragonSlayer.goToBattle()
 ```
 
-The program output is the same as the above one.
+The program output is the same as the above.
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    %% Class-based strategy variant
     class DragonSlayingStrategy {
         <<fun interface>>
-        +execute()*
+        +execute()
     }
     class DragonSlayer {
-        -DragonSlayingStrategy strategy
-        +changeStrategy(strategy DragonSlayingStrategy)
+        -strategy DragonSlayingStrategy
+        +changeStrategy(DragonSlayingStrategy)
         +goToBattle()
     }
     class MeleeStrategy {
@@ -235,25 +258,23 @@ classDiagram
     ProjectileStrategy ..|> DragonSlayingStrategy
     SpellStrategy ..|> DragonSlayingStrategy
 
-    %% Enum-based strategy variant
     class EnumStrategy {
         <<outer class>>
     }
-    class EnumStrategy_Strategy {
+    class Strategy {
         <<enumeration>>
-        +MELEE_STRATEGY
-        +PROJECTILE_STRATEGY
-        +SPELL_STRATEGY
-        -DragonSlayingStrategy dragonSlayingStrategy
+        MELEE_STRATEGY
+        PROJECTILE_STRATEGY
+        SPELL_STRATEGY
+        -dragonSlayingStrategy DragonSlayingStrategy
         +execute()
     }
-    EnumStrategy *-- EnumStrategy_Strategy
-    EnumStrategy_Strategy ..|> DragonSlayingStrategy
+    EnumStrategy *-- Strategy
+    Strategy ..|> DragonSlayingStrategy
 
-    %% Functional strategy variant
     class FunctionalDragonSlayer {
-        -Strategy strategy
-        +changeStrategy(strategy Strategy)
+        -strategy Strategy~lambda~
+        +changeStrategy(Strategy)
         +goToBattle()
     }
     class LambdaStrategy {
@@ -267,26 +288,53 @@ classDiagram
 
 ## Applicability
 
-Use the Strategy pattern when
+Use the Strategy pattern when:
 
-- Many related classes differ only in their behavior. Strategies provide a way
-  to configure a class either one of many behaviors
-- You need different variants of an algorithm. for example, you might define
-  algorithms reflecting different space/time trade-offs. Strategies can be used
-  when these variants are implemented as a class hierarchy of algorithms
-- An algorithm uses data that clients shouldn't know about. Use the Strategy
-  pattern to avoid exposing complex algorithm-specific data structures
-- A class defines many behaviors, and these appear as multiple conditional
-  statements in its operations. Instead of many conditionals, move the related
-  conditional branches into their own Strategy class
+- You need to use different variants of an algorithm
+  within an object and want to switch algorithms at
+  runtime.
+- Many related classes differ only in their behavior.
+  Strategies provide a way to configure a class with
+  one of many behaviors.
+- An algorithm uses data that clients shouldn't know
+  about. Use the Strategy pattern to avoid exposing
+  complex algorithm-specific data structures.
+- A class defines many behaviors, and these appear as
+  multiple conditional statements in its operations.
+  Instead of many conditionals, move the related
+  conditional branches into their own Strategy class.
 
-## Tutorial
+## Consequences
 
-- [Strategy Pattern Tutorial](https://www.journaldev.com/1754/strategy-design-pattern-in-java-example-tutorial)
+Benefits:
+
+- Families of related algorithms are reused.
+- An alternative to subclassing for extending behavior.
+- Avoids conditional statements for selecting desired
+  behavior.
+- Allows clients to choose algorithm implementation.
+
+Trade-offs:
+
+- Clients must be aware of different strategies.
+- Increases the number of objects.
+
+## Related Patterns
+
+- [Decorator](../decorator/README.md): Enhances an
+  object without changing its interface but is more
+  concerned with responsibilities than algorithms.
+- [State](../state/README.md): Similar in structure
+  but used to represent state-dependent behavior rather
+  than interchangeable algorithms.
 
 ## Credits
 
-- [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/gp/product/0201633612/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0201633612&linkCode=as2&tag=javadesignpat-20&linkId=675d49790ce11db99d90bde47f1aeb59)
-- [Functional Programming in Java: Harnessing the Power of Java 8 Lambda Expressions](https://www.amazon.com/gp/product/1937785467/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1937785467&linkCode=as2&tag=javadesignpat-20&linkId=7e4e2fb7a141631491534255252fd08b)
-- [Head First Design Patterns: A Brain-Friendly Guide](https://www.amazon.com/gp/product/0596007124/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0596007124&linkCode=as2&tag=javadesignpat-20&linkId=6b8b6eea86021af6c8e3cd3fc382cb5b)
-- [Refactoring to Patterns](https://www.amazon.com/gp/product/0321213351/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0321213351&linkCode=as2&tag=javadesignpat-20&linkId=2a76fcb387234bc71b1c61150b3cc3a7)
+- [Design Patterns: Elements of Reusable Object-Oriented
+  Software](https://amzn.to/3w0pvKI)
+- [Functional Programming in
+  Java](https://amzn.to/3JUIc5Q)
+- [Head First Design Patterns: Building Extensible and
+  Maintainable Object-Oriented
+  Software](https://amzn.to/49NGldq)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/App.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/App.kt
@@ -42,7 +42,7 @@ fun main() {
 
     // functional interface implementation Strategy pattern
     logger.info(GREEN_DRAGON_SPOTTED)
-    val functionalDragonSlayer = DragonSlayer { logger.info("With your Excalibur you severe the dragon's head!") }
+    val functionalDragonSlayer = DragonSlayer { logger.info("With your Excalibur you sever the dragon's head!") }
     functionalDragonSlayer.goToBattle()
 
     logger.info(RED_DRAGON_EMERGES)

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/DragonSlayer.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/DragonSlayer.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.strategy
 
 /**
- * DragonSlayer uses different strategies to slay the dragon.
+ * Context that delegates dragon-slaying to a [DragonSlayingStrategy].
  */
 internal class DragonSlayer(private var strategy: DragonSlayingStrategy) {
     fun changeStrategy(strategy: DragonSlayingStrategy) {

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/DragonSlayingStrategy.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/DragonSlayingStrategy.kt
@@ -1,9 +1,8 @@
 package com.yonatankarp.strategy
 
 /**
- * Strategy interface.
+ * Encapsulates a dragon-slaying algorithm.
  */
-// TODO: make internal once this issue is fixed in Spotless: https://github.com/diffplug/spotless/issues/1865
 fun interface DragonSlayingStrategy {
     fun execute()
 }

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/EnumStrategy.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/EnumStrategy.kt
@@ -1,11 +1,13 @@
 package com.yonatankarp.strategy
 
 /**
- * Enum strategy pattern.
+ * Demonstrates the strategy pattern using an enum that
+ * delegates to [DragonSlayingStrategy] instances.
  */
 internal class EnumStrategy {
     /**
-     * Enum to demonstrate strategy pattern.
+     * Enum entries that each delegate to a
+     * [DragonSlayingStrategy] lambda.
      */
     internal enum class Strategy(private val dragonSlayingStrategy: DragonSlayingStrategy) :
         DragonSlayingStrategy {

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/FunctionalDragonSlayer.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/FunctionalDragonSlayer.kt
@@ -3,8 +3,7 @@ package com.yonatankarp.strategy
 internal typealias Strategy = () -> Unit
 
 /**
- * FunctionalDragonSlayer uses different strategies to slay the dragon that are
- * based on lambdas
+ * Context that delegates dragon-slaying to a lambda [Strategy].
  */
 internal class FunctionalDragonSlayer(private var strategy: Strategy) {
     fun changeStrategy(strategy: Strategy) {

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/LambdaStrategy.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/LambdaStrategy.kt
@@ -1,6 +1,10 @@
 package com.yonatankarp.strategy
 
-object LambdaStrategy {
+/**
+ * Strategy implementations as standalone functions,
+ * used with [FunctionalDragonSlayer] via method references.
+ */
+internal object LambdaStrategy {
     fun meleeStrategy() =
         logger.info("With your Excalibur you sever the dragon's head!")
 

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/MeleeStrategy.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/MeleeStrategy.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.strategy
 
 /**
- * Melee strategy.
+ * A [DragonSlayingStrategy] using close-combat melee attacks.
  */
 internal class MeleeStrategy : DragonSlayingStrategy {
     override fun execute() {

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/ProjectileStrategy.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/ProjectileStrategy.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.strategy
 
 /**
- * Projectile strategy.
+ * A [DragonSlayingStrategy] using ranged projectile attacks.
  */
 internal class ProjectileStrategy : DragonSlayingStrategy {
     override fun execute() {

--- a/strategy/src/main/kotlin/com/yonatankarp/strategy/SpellStrategy.kt
+++ b/strategy/src/main/kotlin/com/yonatankarp/strategy/SpellStrategy.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.strategy
 
 /**
- * Spell strategy.
+ * A [DragonSlayingStrategy] using magical spell attacks.
  */
 internal class SpellStrategy : DragonSlayingStrategy {
     override fun execute() {

--- a/strategy/src/test/kotlin/com/yonatankarp/strategy/AppTest.kt
+++ b/strategy/src/test/kotlin/com/yonatankarp/strategy/AppTest.kt
@@ -8,7 +8,5 @@ import org.junit.jupiter.api.assertDoesNotThrow
  */
 internal class AppTest {
     @Test
-    fun `should execute without exception`() {
-        assertDoesNotThrow { main() }
-    }
+    fun `should execute without exception`() = assertDoesNotThrow { main() }
 }

--- a/strategy/src/test/kotlin/com/yonatankarp/strategy/DragonSlayerTest.kt
+++ b/strategy/src/test/kotlin/com/yonatankarp/strategy/DragonSlayerTest.kt
@@ -22,18 +22,22 @@ internal class DragonSlayerTest {
 
     @Test
     fun `test change strategy`() {
+        // Given
         val initialStrategy = spyk<DragonSlayingStrategy>()
         val dragonSlayer = DragonSlayer(initialStrategy)
 
+        // When
         dragonSlayer.goToBattle()
 
+        // Then
         verify(exactly = 1) { initialStrategy.execute() }
 
+        // When
         val newStrategy = spyk<DragonSlayingStrategy>()
         dragonSlayer.changeStrategy(newStrategy)
-
         dragonSlayer.goToBattle()
 
+        // Then
         verify(exactly = 1) { newStrategy.execute() }
         confirmVerified(initialStrategy, newStrategy)
     }

--- a/strategy/src/test/kotlin/com/yonatankarp/strategy/DragonSlayingStrategyTest.kt
+++ b/strategy/src/test/kotlin/com/yonatankarp/strategy/DragonSlayingStrategyTest.kt
@@ -27,7 +27,10 @@ internal class DragonSlayingStrategyTest {
     @ParameterizedTest(name = "test execute {0}")
     @MethodSource("dataProvider")
     fun `test execute`(strategy: DragonSlayingStrategy, expectedResult: String) {
+        // When
         strategy.execute()
+
+        // Then
         assertEquals(expectedResult, appender.lastMessage)
         assertEquals(1, appender.logSize)
     }

--- a/strategy/src/test/kotlin/com/yonatankarp/strategy/FunctionalDragonSlayerTest.kt
+++ b/strategy/src/test/kotlin/com/yonatankarp/strategy/FunctionalDragonSlayerTest.kt
@@ -22,18 +22,22 @@ internal class FunctionalDragonSlayerTest {
 
     @Test
     fun `test change strategy`() {
+        // Given
         val initialStrategy = spyk<Strategy>()
-        val dragonSlayer = DragonSlayer(initialStrategy)
+        val dragonSlayer = FunctionalDragonSlayer(initialStrategy)
 
+        // When
         dragonSlayer.goToBattle()
 
+        // Then
         verify(exactly = 1) { initialStrategy.invoke() }
 
+        // When
         val newStrategy = spyk<Strategy>()
         dragonSlayer.changeStrategy(newStrategy)
-
         dragonSlayer.goToBattle()
 
+        // Then
         verify(exactly = 1) { newStrategy.invoke() }
         confirmVerified(initialStrategy, newStrategy)
     }


### PR DESCRIPTION
## Description

Aligns the existing strategy pattern implementation with the project's porting standards.

### Main changes

- Fixed typo "severe" → "sever" in `App.kt` functional lambda
- Fixed bug in `FunctionalDragonSlayerTest` — was using `DragonSlayer` instead of `FunctionalDragonSlayer` in the change-strategy test
- Removed stale TODO comment from `DragonSlayingStrategy` (referenced Spotless issue #1865)
- Added `internal` visibility to `LambdaStrategy`
- Improved KDoc on all classes — replaced tautological names with meaningful descriptions using `[ClassName]` references
- Added missing frontmatter tags from Java source: Decoupling, Extensibility, Interface, Polymorphism
- Added Consequences and Related Patterns sections to README
- Expanded README programmatic example to show all four strategy variants (GoF classes, fun-interface lambdas, enum-based, functional typealias)
- Added Given/When/Then comments to multi-step tests
- Wrapped README prose to ≤80 chars, updated book links to short URLs

### Additional information

- `DragonSlayingStrategy` kept as `fun interface` without `internal` because diktat 1.2.3 cannot parse `internal fun interface`
- Part of the pattern alignment project — aligning all 24 existing patterns to match porting skill standards