### PR TITLE
Align prototype pattern with project standards

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -5,121 +5,137 @@ language: en
 tag:
   - Gang of Four
   - Instantiation
+  - Object composition
+  - Polymorphism
 ---
+
+## Also known as
+
+- Clone
 
 ## Intent
 
-Specify the kinds of objects to create using a prototypical instance, and create
-new objects by copying this prototype.
+Specify the kinds of objects to create using a
+prototypical instance, and create new objects by
+copying this prototype.
 
 ## Explanation
 
-First, it should be noted that the Prototype pattern is not used to gain
-performance benefits. It's only used for creating new objects from prototype
-instances.
+### Real-world example
 
-Real-world example
+> Imagine a company that manufactures custom-designed
+> furniture. Instead of creating each piece from scratch
+> every time an order is placed, they keep prototypes of
+> their most popular designs. When a customer places an
+> order, the company clones the prototype and makes the
+> necessary customizations.
 
-> Remember Dolly? The sheep that was cloned! Let's not get into the details but
-> the key point here is that it is all about cloning.
+### In plain words
 
-In plain words
+> Create an object based on an existing object through
+> cloning.
 
-> Create an object based on an existing object through cloning.
+### Wikipedia says
 
-Wikipedia says
-
-> The prototype pattern is a creational design pattern in software development.
-> It is used when the type of objects to create is determined by a prototypical
+> The prototype pattern is a creational design pattern
+> in software development. It is used when the type of
+> objects to create is determined by a prototypical
 > instance, which is cloned to produce new objects.
 
-In short, it allows you to create a copy of an existing object and modify it to
-your needs, instead of going through the trouble of creating an object from
-scratch and setting it up.
+```mermaid
+sequenceDiagram
+    participant Client
+    participant HeroFactory
+    participant Prototype
 
-### Programmatic Example
+    Client->>HeroFactory: createMage()
+    HeroFactory->>Prototype: clone()
+    Prototype-->>HeroFactory: cloned Mage
+    HeroFactory-->>Client: Mage
+```
 
-In Kotlin, the prototype pattern is recommended to be implemented as follows.
-First, create an interface with a method for cloning objects. In this example,
-`Prototype` interface accomplishes this with its `clone` method. We will then
-use the `copy()` function of data class to create a clone of our class where
-we can override specific fields of the class if needed.
+### **Programmatic Example**
+
+In Kotlin, the prototype pattern leverages `data class`
+`copy()` for cloning. First, create an abstract base
+with a `clone` method.
 
 ```kotlin
 abstract class Prototype<T> {
-  abstract fun clone(): T
+    abstract fun clone(): T
 }
 ```
 
-Our example contains a hierarchy of different creatures. For example, let's
-look at `Beast` and `OrcBeast` classes.
+Our example contains a hierarchy of different
+creatures. For example, let's look at `Beast` and
+`OrcBeast` classes.
 
 ```kotlin
 abstract class Beast : Prototype<Beast>()
 
-data class OrcBeast(private val weapon: String) : Beast() {
-    
-  override fun clone() = copy()
+data class OrcBeast(
+    private val weapon: String,
+) : Beast() {
+    override fun clone() = copy()
 
-  override fun toString() = "Orcish wolf attacks with $weapon"
+    override fun toString() =
+        "Orcish wolf attacks with $weapon"
 }
 ```
 
-We don't want to go into too many details, but the full example contains also
-base classes `Mage` and `Warlord` and there are specialized implementations for
-those for elves in addition to orcs.
+The full example also contains `Mage` and `Warlord`
+base classes with elven and orcish implementations.
 
-To take full advantage of the prototype pattern, we create `HeroFactory` class
-to produce different kinds of creatures from prototypes.
+To take full advantage of the prototype pattern, we
+create `HeroFactory` to produce different kinds of
+creatures from prototypes.
 
 ```kotlin
 class HeroFactory(
-  private val mage: Mage,
-  private val warlord: Warlord,
-  private val beast: Beast,
+    private val mage: Mage,
+    private val warlord: Warlord,
+    private val beast: Beast,
 ) {
-  fun createMage() = mage.clone()
-  
-  fun createWarlord() = warlord.clone()
-  
-  fun createBeast() = beast.clone()
+    fun createMage() = mage.clone()
+    fun createWarlord() = warlord.clone()
+    fun createBeast() = beast.clone()
 }
 ```
 
-Now, we are able to show the full prototype pattern in action producing new
-creatures by cloning existing instances.
+Now we can produce new creatures by cloning existing
+instances.
 
 ```kotlin
-var factory = HeroFactory(
-  ElfMage("cooking"),
-  ElfWarlord("cleaning"),
-  ElfBeast("protecting")
+val elfFactory = HeroFactory(
+    ElfMage("cooking"),
+    ElfWarlord("cleaning"),
+    ElfBeast("protecting")
 )
 
-var mage = factory.createMage()
-var warlord = factory.createWarlord()
-var beast = factory.createBeast()
+val elfMage = elfFactory.createMage()
+val elfWarlord = elfFactory.createWarlord()
+val elfBeast = elfFactory.createBeast()
 
-logger.info(mage.toString())
-logger.info(warlord.toString())
-logger.info(beast.toString())
+logger.info(elfMage.toString())
+logger.info(elfWarlord.toString())
+logger.info(elfBeast.toString())
 
-factory = HeroFactory(
-  OrcMage("axe"),
-  OrcWarlord("sword"),
-  OrcBeast("laser")
+val orcFactory = HeroFactory(
+    OrcMage("axe"),
+    OrcWarlord("sword"),
+    OrcBeast("laser")
 )
 
-mage = factory.createMage()
-warlord = factory.createWarlord()
-beast = factory.createBeast()
+val orcMage = orcFactory.createMage()
+val orcWarlord = orcFactory.createWarlord()
+val orcBeast = orcFactory.createBeast()
 
-logger.info(mage.toString())
-logger.info(warlord.toString())
-logger.info(beast.toString())
+logger.info(orcMage.toString())
+logger.info(orcWarlord.toString())
+logger.info(orcBeast.toString())
 ```
 
-Here's the console output from running the example.
+Program output:
 
 ```text
 Elven mage helps in cooking
@@ -136,64 +152,61 @@ Orcish wolf attacks with laser
 classDiagram
     class Prototype~T~ {
         <<abstract>>
-        +clone() T*
+        +clone() T
     }
     class Beast {
         <<abstract>>
-        +clone() Beast*
     }
     class Mage {
         <<abstract>>
-        +clone() Mage*
     }
     class Warlord {
         <<abstract>>
-        +clone() Warlord*
     }
     class HeroFactory {
-        -Beast beast
-        -Mage mage
-        -Warlord warlord
+        -beast Beast
+        -mage Mage
+        -warlord Warlord
         +createBeast() Beast
         +createMage() Mage
         +createWarlord() Warlord
     }
     class ElfBeast {
-        -String helpType
+        -helpType String
         +clone() ElfBeast
         +toString() String
     }
     class ElfMage {
-        -String helpType
+        -helpType String
         +clone() ElfMage
         +toString() String
     }
     class ElfWarlord {
-        -String helpType
+        -helpType String
         +clone() ElfWarlord
         +toString() String
     }
     class OrcBeast {
-        -String weapon
+        -weapon String
         +clone() OrcBeast
         +toString() String
     }
     class OrcMage {
-        -String weapon
+        -weapon String
         +clone() OrcMage
         +toString() String
     }
     class OrcWarlord {
-        -String weapon
+        -weapon String
         +clone() OrcWarlord
         +toString() String
     }
     HeroFactory --> Beast : beast
     HeroFactory --> Warlord : warlord
     HeroFactory --> Mage : mage
-    Beast ..|> Prototype~T~
-    Mage ..|> Prototype~T~
-    Warlord ..|> Prototype~T~
+    Beast --|> Prototype~T~
+    Mage --|> Prototype~T~
+    Warlord --|> Prototype~T~
     ElfBeast --|> Beast
     ElfMage --|> Mage
     ElfWarlord --|> Warlord
@@ -204,20 +217,49 @@ classDiagram
 
 ## Applicability
 
-Use the Prototype pattern when a system should be independent of how its
-products are created, composed, represented and
+Use the Prototype pattern when:
 
-- When the classes to instantiate are specified at run-time, for example, by
-  dynamic loading.
-- To avoid building a class hierarchy of factories that parallels the class
-  hierarchy of products.
-- When instances of a class can have one of only a few different combinations
-  of state. It may be more convenient to install a corresponding number of
-  prototypes and clone them rather than instantiating the class manually, each
-  time with the appropriate state.
-- When object creation is expensive compared to cloning.
+- The classes to instantiate are specified at run-time,
+  for example by dynamic loading.
+- To avoid building a class hierarchy of factories
+  that parallels the class hierarchy of products.
+- When instances of a class can have one of only a few
+  different combinations of state. It may be more
+  convenient to install a corresponding number of
+  prototypes and clone them rather than instantiating
+  the class manually each time.
+- When object creation is expensive compared to
+  cloning.
+
+## Consequences
+
+Benefits:
+
+- Hides the complexities of instantiating new objects.
+- Reduces the number of classes.
+- Allows adding and removing objects at runtime.
+
+Trade-offs:
+
+- Requires implementing a cloning mechanism which
+  might be complex.
+- Deep cloning can be difficult to implement correctly,
+  especially with complex object graphs or circular
+  references.
+
+## Related Patterns
+
+- [Abstract Factory](../abstract-factory/README.md):
+  Both create objects, but Prototype uses cloning
+  whereas Abstract Factory uses factory methods.
+- [Factory Method](../factory-method/README.md): A
+  factory method that returns a new instance cloned
+  from a prototype.
 
 ## Credits
 
-- [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/gp/product/0201633612/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0201633612&linkCode=as2&tag=javadesignpat-20&linkId=675d49790ce11db99d90bde47f1aeb59)
-- [Head First Design Patterns: A Brain-Friendly Guide](https://www.amazon.com/gp/product/0596007124/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0596007124&linkCode=as2&tag=javadesignpat-20&linkId=6b8b6eea86021af6c8e3cd3fc382cb5b)
+- [Design Patterns: Elements of Reusable Object-Oriented
+  Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible and
+  Maintainable Object-Oriented
+  Software](https://amzn.to/49NGldq)

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/Beast.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/Beast.kt
@@ -1,3 +1,6 @@
 package com.yonatankarp.prototype
 
+/**
+ * Abstract [Prototype] representing a beast creature.
+ */
 abstract class Beast : Prototype<Beast>()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/ElfBeast.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/ElfBeast.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.prototype
 
 /**
- * ElfBeast.
+ * An elven [Beast] that can be cloned via [copy].
  */
 data class ElfBeast(private val helpType: String) : Beast() {
     override fun clone() = copy()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/ElfMage.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/ElfMage.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.prototype
 
 /**
- * ElfMage
+ * An elven [Mage] that can be cloned via [copy].
  */
 data class ElfMage(private val helpType: String) : Mage() {
     override fun clone() = copy()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/ElfWarlord.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/ElfWarlord.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.prototype
 
 /**
- * ElfWarlord.
+ * An elven [Warlord] that can be cloned via [copy].
  */
 data class ElfWarlord(private val helpType: String) : Warlord() {
     override fun clone() = copy()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/HeroFactory.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/HeroFactory.kt
@@ -1,22 +1,26 @@
 package com.yonatankarp.prototype
 
+/**
+ * Factory that creates new creatures by cloning prototype
+ * [Mage], [Warlord], and [Beast] instances.
+ */
 class HeroFactory(
     private val mage: Mage,
     private val warlord: Warlord,
     private val beast: Beast,
 ) {
     /**
-     * Create Mage.
+     * Returns a clone of the prototype [Mage].
      */
     fun createMage() = mage.clone()
 
     /**
-     * Create Warlord.
+     * Returns a clone of the prototype [Warlord].
      */
     fun createWarlord() = warlord.clone()
 
     /**
-     * Create Beast.
+     * Returns a clone of the prototype [Beast].
      */
     fun createBeast() = beast.clone()
 }

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/Mage.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/Mage.kt
@@ -1,3 +1,6 @@
 package com.yonatankarp.prototype
 
+/**
+ * Abstract [Prototype] representing a mage creature.
+ */
 abstract class Mage : Prototype<Mage>()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/OrcBeast.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/OrcBeast.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.prototype
 
 /**
- * OrcBeast.
+ * An orcish [Beast] that can be cloned via [copy].
  */
 data class OrcBeast(private val weapon: String) : Beast() {
     override fun clone() = copy()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/OrcMage.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/OrcMage.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.prototype
 
 /**
- * OrcMage.
+ * An orcish [Mage] that can be cloned via [copy].
  */
 data class OrcMage(private val weapon: String) : Mage() {
     override fun clone() = copy()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/OrcWarlord.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/OrcWarlord.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.prototype
 
 /**
- * OrcWarlord.
+ * An orcish [Warlord] that can be cloned via [copy].
  */
 data class OrcWarlord(private val weapon: String) : Warlord() {
     override fun clone() = copy()

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/Prototype.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/Prototype.kt
@@ -1,11 +1,11 @@
 package com.yonatankarp.prototype
 
 /**
- * Prototype.
+ * Abstract base for objects that can produce copies of themselves.
  */
 abstract class Prototype<T> {
     /**
-     * Object a shallow copy of this object or null if this object is not Cloneable.
+     * Returns a shallow copy of this instance.
      */
     abstract fun clone(): T
 }

--- a/prototype/src/main/kotlin/com/yonatankarp/prototype/Warlord.kt
+++ b/prototype/src/main/kotlin/com/yonatankarp/prototype/Warlord.kt
@@ -1,3 +1,6 @@
 package com.yonatankarp.prototype
 
+/**
+ * Abstract [Prototype] representing a warlord creature.
+ */
 abstract class Warlord : Prototype<Warlord>()

--- a/prototype/src/test/kotlin/com/yonatankarp/prototype/AppTest.kt
+++ b/prototype/src/test/kotlin/com/yonatankarp/prototype/AppTest.kt
@@ -5,7 +5,5 @@ import org.junit.jupiter.api.assertDoesNotThrow
 
 internal class AppTest {
     @Test
-    fun `should execute without exception`() {
-        assertDoesNotThrow { main() }
-    }
+    fun `should execute without exception`() = assertDoesNotThrow { main() }
 }

--- a/prototype/src/test/kotlin/com/yonatankarp/prototype/PrototypeTest.kt
+++ b/prototype/src/test/kotlin/com/yonatankarp/prototype/PrototypeTest.kt
@@ -7,19 +7,20 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 /**
- * Date: 12/28/15 - 8:45 PM
- *
- * @param <P> Prototype
- * @author Jeroen Meulemeester
-</P> */
+ * Verifies that each [Prototype] implementation correctly
+ * clones itself as a distinct but equal instance.
+ */
 internal class PrototypeTest<P : Prototype<P>> {
     @ParameterizedTest
     @MethodSource("dataProvider")
     fun `test prototype`(testedPrototype: P, expectedToString: String) {
+        // Given
         assertEquals(expectedToString, testedPrototype.toString())
 
+        // When
         val clone = testedPrototype.clone()
 
+        // Then
         assertNotSame(clone, testedPrototype)
         assertSame(testedPrototype::class.java, clone::class.java)
         assertEquals(clone, testedPrototype)


### PR DESCRIPTION
## Description

Aligns the existing prototype pattern implementation with the project's porting standards.

### Main changes

- Improved KDoc on all 12 classes — replaced tautological names and JavaDoc-style docs with meaningful descriptions using `[ClassName]` references
- Added missing KDoc to `Beast`, `Mage`, `Warlord` abstract classes
- Replaced JavaDoc-style test KDoc (`@param <P>`, `@author`) with proper KDoc
- Added missing frontmatter tags from Java source: Object composition, Polymorphism
- Added Also known as section (Clone)
- Added Mermaid sequence diagram (from Java repo's `etc/prototype-sequence-diagram.png`)
- Removed `*` from class diagram abstract return types
- Added Consequences and Related Patterns sections
- Added `###` headers, bolded Programmatic Example
- Wrapped prose to ≤80 chars, updated book links to short URLs
- Added Given/When/Then to multi-step prototype test
- Converted one-liner test to expression body

### Additional information

Part of the pattern alignment project — aligning all 24 existing patterns to match porting skill standards.