### PR TITLE
Align builder pattern with project standards

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -4,113 +4,134 @@ category: Creational
 language: en
 tag:
   - Gang of Four
+  - Instantiation
+  - Object composition
 ---
 
 ## Intent
 
-Separate the construction of a complex object from its representation so that
-the same construction process can create different representations.
+Separate the construction of a complex object from its
+representation so that the same construction process can
+create different representations.
 
 ## Explanation
 
-Real-world example
+### Real-world example
 
-> Imagine a character generator for a role-playing game. The easiest option is
-> to let the computer create the character for you. If you want to manually
-> select the character details like profession, gender, hair color, etc. the
-> character generation becomes a step-by-step process that completes when all
-> the selections are ready.
+> Imagine a character generator for a role-playing game.
+> The easiest option is to let the computer create the
+> character for you. If you want to manually select the
+> character details like profession, gender, hair color,
+> etc. the character generation becomes a step-by-step
+> process that completes when all the selections are ready.
 
-In plain words
+### In plain words
 
-> Allows you to create different flavors of an object while avoiding constructor
-> pollution. Useful when there could be several flavors of an object. Or when
-> there are a lot of steps involved in creation of an object.
+> Allows you to create different flavors of an object while
+> avoiding constructor pollution. Useful when there could be
+> several flavors of an object. Or when there are a lot of
+> steps involved in creation of an object.
 
-Wikipedia says
+### Wikipedia says
 
-> The builder pattern is an object creation software design pattern with the
-> intentions of finding a solution to the telescoping constructor anti-pattern.
+> The builder pattern is an object creation software design
+> pattern with the intentions of finding a solution to the
+> telescoping constructor anti-pattern.
 
-Having said that let me add a bit about what telescoping constructor
-anti-pattern is. At one point or the other, we have all seen a constructor like
-below:
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Builder
+    participant Hero
+    Client->>Builder: Builder(profession, name)
+    Client->>Builder: withHairColor(BLACK)
+    Client->>Builder: withWeapon(DAGGER)
+    Client->>Builder: build()
+    Builder->>Hero: Hero(builder)
+    Hero-->>Builder: hero
+    Builder-->>Client: hero
+```
+
+Having said that let me add a bit about what telescoping
+constructor anti-pattern is. At one point or the other, we
+have all seen a constructor like below:
 
 ```kotlin
 data class Hero(
-  val profession: Profession,
-  val name: String,
-  val hairType: HairType?,
-  val hairColor: HairColor?,
-  val armor: Armor?,
-  val weapon: Weapon?
+    val profession: Profession,
+    val name: String,
+    val hairType: HairType?,
+    val hairColor: HairColor?,
+    val armor: Armor?,
+    val weapon: Weapon?,
 )
 ```
 
-As you can see the number of constructor parameters can quickly get out of hand,
-and it may become difficult to understand the arrangement of parameters. Plus
-this parameter list could keep on growing if you would want to add more options
-in the future. This is called telescoping constructor anti-pattern.
+As you can see the number of constructor parameters can
+quickly get out of hand, and it may become difficult to
+understand the arrangement of parameters. Plus this
+parameter list could keep on growing if you would want to
+add more options in the future. This is called telescoping
+constructor anti-pattern.
 
-### Programmatic Example
+### **Programmatic Example**
 
-The sane alternative is to use the Builder pattern. First of all, we have our
-hero that we want to create:
+The sane alternative is to use the Builder pattern. First
+of all, we have our hero that we want to create:
 
 ```kotlin
-data class Hero(
-  val profession: Profession,
-  val name: String,
-  val hairType: HairType?,
-  val hairColor: HairColor?,
-  val armor: Armor?,
-  val weapon: Weapon?
+internal data class Hero(
+    val profession: Profession,
+    val name: String,
+    val hairType: HairType?,
+    val hairColor: HairColor?,
+    val armor: Armor?,
+    val weapon: Weapon?,
 ) {
-  private constructor(builder: Builder) : this(
-    builder.profession,
-    builder.name,
-    builder.hairType,
-    builder.hairColor,
-    builder.armor,
-    builder.weapon
-  )
+    private constructor(builder: Builder) : this(
+        builder.profession,
+        builder.name,
+        builder.hairType,
+        builder.hairColor,
+        builder.armor,
+        builder.weapon,
+    )
 }
 ```
 
 Then we have the builder:
 
 ```kotlin
-class Builder(profession: Profession?, name: String?) {
-  val profession: Profession
-  val name: String
-  var hairType: HairType? = null
-  var hairColor: HairColor? = null
-  var armor: Armor? = null
-  var weapon: Weapon? = null
+internal class Builder(
+    profession: Profession?,
+    name: String?,
+) {
+    val profession: Profession =
+        requireNotNull(profession) { "profession can not be null" }
+    val name: String =
+        requireNotNull(name) { "name can not be null" }
+    var hairType: HairType? = null
+    var hairColor: HairColor? = null
+    var armor: Armor? = null
+    var weapon: Weapon? = null
 
-  init {
-    require(!(profession == null || name == null)) { "profession and name can not be null" }
-    this.profession = profession
-    this.name = name
-  }
+    fun withHairType(hairType: HairType?): Builder = apply {
+        this.hairType = hairType
+    }
 
-  fun withHairType(hairType: HairType?): Builder = apply {
-    this.hairType = hairType
-  }
+    fun withHairColor(hairColor: HairColor?): Builder = apply {
+        this.hairColor = hairColor
+    }
 
-  fun withHairColor(hairColor: HairColor?): Builder = apply {
-    this.hairColor = hairColor
-  }
+    fun withArmor(armor: Armor?): Builder = apply {
+        this.armor = armor
+    }
 
-  fun withArmor(armor: Armor?): Builder = apply {
-    this.armor = armor
-  }
+    fun withWeapon(weapon: Weapon?): Builder = apply {
+        this.weapon = weapon
+    }
 
-  fun withWeapon(weapon: Weapon?): Builder = apply {
-    this.weapon = weapon
-  }
-
-  fun build() = Hero(this)
+    fun build() = Hero(this)
 }
 ```
 
@@ -118,38 +139,46 @@ Then it can be used as:
 
 ```kotlin
 val mage = Hero.Builder(Profession.MAGE, "Riobard")
-  .withHairColor(HairColor.BLACK)
-  .withWeapon(Weapon.DAGGER)
-  .build() 
+    .withHairColor(HairColor.BLACK)
+    .withWeapon(Weapon.DAGGER)
+    .build()
 ```
 
-However, Kotlin provides an alternative to the Builder pattern with named
-arguments and default parameter values:
+However, Kotlin provides an alternative to the Builder
+pattern with named arguments and default parameter values:
 
 ```kotlin
-data class Hero(
+internal data class NamedArgumentsHero(
     val profession: Profession,
     val name: String,
     val hairType: HairType? = null,
     val hairColor: HairColor? = null,
     val armor: Armor? = null,
-    val weapon: Weapon? = null
+    val weapon: Weapon? = null,
 )
 ```
 
 Then it can be used as:
 
 ```kotlin
-val mage = Hero(
+val mage = NamedArgumentsHero(
     profession = Profession.MAGE,
     name = "Riobard",
     hairColor = HairColor.BLACK,
-    weapon = Weapon.DAGGER
+    weapon = Weapon.DAGGER,
 )
 ```
 
-Not only that the code is simpler, we are also enforcing the required parameters
-at compile time.
+Not only is the code simpler, we are also enforcing the
+required parameters at compile time.
+
+Program output:
+
+```text
+This is a mage named Riobard with black hair and wielding a dagger.
+This is a warrior named Amberjill with blond long curly hair wearing chain mail and wielding a sword.
+This is a thief named Desmond with bald head and wielding a bow.
+```
 
 ## Class diagram
 
@@ -161,7 +190,7 @@ classDiagram
         CLOTHES
         LEATHER
         PLATE_MAIL
-        -String title
+        -title: String
         +toString() String
     }
     class HairColor {
@@ -180,7 +209,7 @@ classDiagram
         LONG_CURLY
         LONG_STRAIGHT
         SHORT
-        -String title
+        -title: String
         +toString() String
     }
     class Profession {
@@ -201,66 +230,103 @@ classDiagram
         +toString() String
     }
     class Hero {
-        -Armor armor
-        -HairColor hairColor
-        -HairType hairType
-        -String name
-        -Profession profession
-        -Weapon weapon
-        +getArmor() Armor
-        +getHairColor() HairColor
-        +getHairType() HairType
-        +getName() String
-        +getProfession() Profession
-        +getWeapon() Weapon
+        +profession: Profession
+        +name: String
+        +hairType: HairType?
+        +hairColor: HairColor?
+        +armor: Armor?
+        +weapon: Weapon?
         +toString() String
     }
     class Builder {
-        -Armor armor
-        -HairColor hairColor
-        -HairType hairType
-        -String name
-        -Profession profession
-        -Weapon weapon
-        +Builder(profession Profession, name String)
+        +profession: Profession
+        +name: String
+        +hairType: HairType?
+        +hairColor: HairColor?
+        +armor: Armor?
+        +weapon: Weapon?
+        +Builder(profession: Profession, name: String)
         +build() Hero
-        +withArmor(armor Armor) Builder
-        +withHairColor(hairColor HairColor) Builder
-        +withHairType(hairType HairType) Builder
-        +withWeapon(weapon Weapon) Builder
+        +withArmor(armor: Armor?) Builder
+        +withHairColor(hairColor: HairColor?) Builder
+        +withHairType(hairType: HairType?) Builder
+        +withWeapon(weapon: Weapon?) Builder
     }
-    Hero --> Profession : profession
+    class NamedArgumentsHero {
+        +profession: Profession
+        +name: String
+        +hairType: HairType?
+        +hairColor: HairColor?
+        +armor: Armor?
+        +weapon: Weapon?
+        +toString() String
+    }
+    Hero --> Profession
+    Hero --> Armor
+    Hero --> HairColor
+    Hero --> HairType
+    Hero --> Weapon
     Builder ..> Hero : creates
-    Hero --> Armor : armor
-    Builder --> HairColor : hairColor
-    Builder --> Weapon : weapon
-    Builder --> HairType : hairType
-    Hero --> HairColor : hairColor
-    Builder --> Profession : profession
-    Hero --> Weapon : weapon
-    Hero --> HairType : hairType
-    Builder --> Armor : armor
+    Builder --> Profession
+    Builder --> Armor
+    Builder --> HairColor
+    Builder --> HairType
+    Builder --> Weapon
+    NamedArgumentsHero --> Profession
+    NamedArgumentsHero --> Armor
+    NamedArgumentsHero --> HairColor
+    NamedArgumentsHero --> HairType
+    NamedArgumentsHero --> Weapon
 ```
 
 ## Applicability
 
 Use the Builder pattern when
 
-- The algorithm for creating a complex object should be independent of the parts
-  that make up the object and how they're assembled
-- The construction process must allow different representations for the object
-  that's constructed
+- The algorithm for creating a complex object should be
+  independent of the parts that make up the object and how
+  they're assembled
+- The construction process must allow different
+  representations for the object that's constructed
+- It's particularly useful when a product requires a lot
+  of steps to be created and when these steps need to be
+  executed in a specific sequence
 
-## Tutorials
+## Consequences
 
-- [Refactoring Guru](https://refactoring.guru/design-patterns/builder)
-- [Oracle Blog](https://blogs.oracle.com/javamagazine/post/exploring-joshua-blochs-builder-design-pattern-in-java)
-- [Journal Dev](https://www.journaldev.com/1425/builder-design-pattern-in-java)
+Benefits:
+
+- More control over the construction process compared to
+  other creational patterns
+- Supports constructing objects step-by-step, defer
+  construction steps or run steps recursively
+- Can construct objects that require a complex assembly of
+  sub-objects. The final product is detached from the parts
+  that make it up, as well as their assembly process
+- Single Responsibility Principle. You can isolate complex
+  construction code from the business logic of the product
+
+Trade-offs:
+
+- The overall complexity of the code can increase since the
+  pattern requires creating multiple new classes
+- May increase memory usage due to the necessity of
+  creating multiple builder objects
+
+## Related Patterns
+
+- [Abstract Factory](https://java-design-patterns.com/patterns/abstract-factory/):
+  Can be used in conjunction with Builder to build parts of
+  a complex object.
+- [Prototype](https://java-design-patterns.com/patterns/prototype/):
+  Builders often create objects from a prototype.
+- [Step Builder](https://java-design-patterns.com/patterns/step-builder/):
+  A variation of the Builder pattern that generates a
+  complex object using a step-by-step approach.
 
 ## Credits
 
-- [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/gp/product/0201633612/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0201633612&linkCode=as2&tag=javadesignpat-20&linkId=675d49790ce11db99d90bde47f1aeb59)
-- [Effective Java](https://www.amazon.com/gp/product/0134685997/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0134685997&linkCode=as2&tag=javadesignpat-20&linkId=4e349f4b3ff8c50123f8147c828e53eb)
-- [Head First Design Patterns: A Brain-Friendly Guide](https://www.amazon.com/gp/product/0596007124/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0596007124&linkCode=as2&tag=javadesignpat-20&linkId=6b8b6eea86021af6c8e3cd3fc382cb5b)
-- [Refactoring to Patterns](https://www.amazon.com/gp/product/0321213351/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0321213351&linkCode=as2&tag=javadesignpat-20&linkId=2a76fcb387234bc71b1c61150b3cc3a7)
-- [Kotlin Design Patterns and Best Practices](https://www.amazon.de/Kotlin-Design-Patterns-Best-Practices/dp/1801815720/ref=sr_1_1?keywords=kotlin+design+patterns+and+best+practices&qid=1694244553&sprefix=kotlin+design%2Caps%2C101&sr=8-1)
+- [Design Patterns: Elements of Reusable Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Effective Java](https://amzn.to/4cGk2Jz)
+- [Head First Design Patterns: Building Extensible and Maintainable Object-Oriented Software](https://amzn.to/49NGldq)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/builder/src/main/kotlin/com/yonatankarp/builder/App.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/App.kt
@@ -19,7 +19,9 @@ import org.slf4j.LoggerFactory
 internal val logger = LoggerFactory.getLogger("com.yonatankarp.builder")
 
 /**
- * Program entry point.
+ * Demonstrates the Builder pattern by constructing [Hero]
+ * instances using both a traditional [Hero.Builder] and
+ * Kotlin's named arguments via [NamedArgumentsHero].
  */
 fun main() {
     // Helper builder class implementation

--- a/builder/src/main/kotlin/com/yonatankarp/builder/Armor.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/Armor.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.builder
 
 /**
- * Armor enumeration.
+ * Represents the type of armor a [Hero] can wear.
  */
 internal enum class Armor(private val title: String) {
     CHAIN_MAIL("chain mail"),

--- a/builder/src/main/kotlin/com/yonatankarp/builder/HairColor.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/HairColor.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.builder
 
 /**
- * HairColor enumeration.
+ * Represents the available hair colors for a [Hero].
  */
 internal enum class HairColor {
     BLACK,

--- a/builder/src/main/kotlin/com/yonatankarp/builder/HairType.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/HairType.kt
@@ -1,5 +1,8 @@
 package com.yonatankarp.builder
 
+/**
+ * Represents the hairstyle of a [Hero].
+ */
 internal enum class HairType(private val title: String) {
     BALD("bald"),
     CURLY("curly"),

--- a/builder/src/main/kotlin/com/yonatankarp/builder/Hero.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/Hero.kt
@@ -1,5 +1,10 @@
 package com.yonatankarp.builder
 
+/**
+ * Represents a role-playing game character constructed via
+ * the [Builder] pattern, with required [profession] and
+ * [name] and optional appearance and equipment attributes.
+ */
 internal data class Hero(
     val profession: Profession,
     val name: String,
@@ -31,7 +36,8 @@ internal data class Hero(
     }
 
     /**
-     * The builder class.
+     * Accumulates optional [Hero] attributes and produces a
+     * fully constructed [Hero] instance via [build].
      */
     internal class Builder(profession: Profession?, name: String?) {
         val profession: Profession = requireNotNull(profession) { "profession can not be null" }

--- a/builder/src/main/kotlin/com/yonatankarp/builder/Profession.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/Profession.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.builder
 
 /**
- * Profession enumeration.
+ * Represents the character class or profession of a [Hero].
  */
 internal enum class Profession {
     MAGE,

--- a/builder/src/main/kotlin/com/yonatankarp/builder/Weapon.kt
+++ b/builder/src/main/kotlin/com/yonatankarp/builder/Weapon.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.builder
 
 /**
- * Weapon enumeration.
+ * Represents the type of weapon a [Hero] can wield.
  */
 internal enum class Weapon {
     AXE,

--- a/builder/src/test/kotlin/com/yonatankarp/builder/AppTest.kt
+++ b/builder/src/test/kotlin/com/yonatankarp/builder/AppTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 
 internal class AppTest {
     @Test
-    fun `should execute without exception`() {
+    fun `should execute without exception`() =
         assertDoesNotThrow { main() }
-    }
 }

--- a/builder/src/test/kotlin/com/yonatankarp/builder/HeroTest.kt
+++ b/builder/src/test/kotlin/com/yonatankarp/builder/HeroTest.kt
@@ -23,8 +23,10 @@ internal class HeroTest {
 
     @Test
     fun `test build default hero`() {
+        // When
         val hero = Hero.Builder(Profession.WARRIOR, "Sir Lancelot").build()
 
+        // Then
         assertNotNull(hero)
         assertNotNull(hero.toString())
         assertEquals(Profession.WARRIOR, hero.profession)
@@ -37,6 +39,7 @@ internal class HeroTest {
 
     @Test
     fun `test build hero`() {
+        // When
         val heroName = "Sir Lancelot"
         val hero = Hero.Builder(Profession.WARRIOR, heroName)
             .withArmor(Armor.CHAIN_MAIL)
@@ -45,6 +48,7 @@ internal class HeroTest {
             .withHairColor(HairColor.BLOND)
             .build()
 
+        // Then
         assertNotNull(hero)
         assertNotNull(hero.toString())
         assertEquals(Profession.WARRIOR, hero.profession)

--- a/builder/src/test/kotlin/com/yonatankarp/builder/NamedArgumentsHeroTest.kt
+++ b/builder/src/test/kotlin/com/yonatankarp/builder/NamedArgumentsHeroTest.kt
@@ -8,11 +8,13 @@ import org.junit.jupiter.api.Test
 class NamedArgumentsHeroTest {
     @Test
     fun `test build default hero`() {
+        // When
         val hero = NamedArgumentsHero(
             profession = Profession.WARRIOR,
-            name = "Sir Lancelot"
+            name = "Sir Lancelot",
         )
 
+        // Then
         assertNotNull(hero)
         assertNotNull(hero.toString())
         assertEquals(Profession.WARRIOR, hero.profession)
@@ -25,14 +27,18 @@ class NamedArgumentsHeroTest {
 
     @Test
     fun `test build hero`() {
+        // When
         val heroName = "Sir Lancelot"
-        val hero = Hero.Builder(Profession.WARRIOR, heroName)
-            .withArmor(Armor.CHAIN_MAIL)
-            .withWeapon(Weapon.SWORD)
-            .withHairType(HairType.LONG_CURLY)
-            .withHairColor(HairColor.BLOND)
-            .build()
+        val hero = NamedArgumentsHero(
+            profession = Profession.WARRIOR,
+            name = heroName,
+            armor = Armor.CHAIN_MAIL,
+            weapon = Weapon.SWORD,
+            hairType = HairType.LONG_CURLY,
+            hairColor = HairColor.BLOND,
+        )
 
+        // Then
         assertNotNull(hero)
         assertNotNull(hero.toString())
         assertEquals(Profession.WARRIOR, hero.profession)


### PR DESCRIPTION
## Description

Aligns the existing builder pattern implementation with the project's porting standards.

### Main changes

- Replaced tautological KDocs with meaningful descriptions using `[ClassName]` references
- Fixed AppTest to use expression body for one-liner assertion
- Added When/Then comments to multi-step tests
- Fixed `NamedArgumentsHeroTest` to actually use `NamedArgumentsHero` (was using `Hero.Builder`)
- Added missing README frontmatter tags from Java source: Instantiation, Object composition
- Added `###` headers, bolded Programmatic Example
- Added inline Mermaid sequence diagram
- Updated class diagram for Kotlin properties (not Java getters)
- Added Consequences and Related Patterns sections
- Dropped Java-specific Tutorials section
- Wrapped prose to ≤80 chars, updated book links to short URLs

### Additional information

Part of the pattern alignment project — aligning all 24 existing patterns to match porting skill standards.