### PR TITLE
Add GitHub Pages site with MkDocs Material

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,49 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install mkdocs-material mkdocs-same-dir
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 
 .DS_Store
 CLAUDE.md
+site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,100 @@
+site_name: Kotlin Design Patterns
+site_url: https://yonatankarp.github.io/kotlin-design-patterns/
+repo_url: https://github.com/yonatankarp/kotlin-design-patterns
+repo_name: yonatankarp/kotlin-design-patterns
+
+docs_dir: .
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - same-dir
+
+exclude_docs: |
+  **/src/**
+  **/build/**
+  **/.gradle/**
+  **/gradle/**
+  **/.github/**
+  **/config/**
+  **/.claude/**
+  **/.git/**
+  **/node_modules/**
+  **/*.kt
+  **/*.kts
+  **/*.toml
+  **/*.yml
+  **/*.yaml
+  **/*.json
+  **/*.properties
+  **/gradlew*
+  **/.gitignore
+  **/LICENSE
+
+nav:
+  - Home: README.md
+  - Categories: DESIGN_PATTERN_CATEGORIES.md
+  - Creational:
+      - Singleton: singleton/README.md
+      - Factory Method: factory-method/README.md
+      - Factory: factory/README.md
+      - Abstract Factory: abstract-factory/README.md
+      - Builder: builder/README.md
+      - Prototype: prototype/README.md
+  - Structural:
+      - Adapter: adapter/README.md
+      - Bridge: bridge/README.md
+      - Composite: composite/README.md
+      - Decorator: decorator/README.md
+      - Facade: facade/README.md
+      - Flyweight: flyweight/README.md
+      - Proxy: proxy/README.md
+  - Behavioral:
+      - Chain of Responsibility: chain-of-responsibility/README.md
+      - Command: command/README.md
+      - Interpreter: interpreter/README.md
+      - Iterator: iterator/README.md
+      - Mediator: mediator/README.md
+      - Memento: memento/README.md
+      - Observer: observer/README.md
+      - State: state/README.md
+      - Strategy: strategy/README.md
+      - Template Method: template-method/README.md
+      - Visitor: visitor/README.md


### PR DESCRIPTION
## Summary
- Set up MkDocs with Material theme to publish pattern docs as a GitHub Pages site
- Includes Mermaid diagram rendering, search, dark mode toggle, and code copy buttons
- Adds a deploy workflow that builds and deploys on push to main

## Test plan
- [ ] Enable GitHub Pages (Settings > Pages > Source: GitHub Actions) if not already configured
- [ ] Verify the GitHub Pages workflow runs successfully after merge
- [ ] Confirm site is live at https://yonatankarp.github.io/kotlin-design-patterns/
- [ ] Check Mermaid diagrams render correctly
- [ ] Test search functionality