### PR TITLE
Add State design pattern implementation

### DIFF
--- a/state/README.md
+++ b/state/README.md
@@ -1,0 +1,230 @@
+---
+title: State
+category: Behavioral
+language: en
+tag:
+  - Decoupling
+  - Gang of Four
+  - State tracking
+---
+
+## Also known as
+
+- Objects for States
+
+## Intent
+
+Allow an object to alter its behavior when its internal
+state changes. The object will appear to change its
+class.
+
+## Explanation
+
+### Real-world example
+
+> Imagine a traffic light system at an intersection.
+> The traffic light can be in one of three states:
+> Green, Yellow, or Red. Depending on the current
+> state, the traffic light's behavior changes. Each
+> state is represented by a different object that
+> defines what happens in that particular state. When
+> the state changes, the traffic light updates its
+> state object and changes its behavior accordingly.
+
+### In plain words
+
+> State pattern allows an object to change its behavior
+> when its internal state changes.
+
+### Wikipedia says
+
+> The state pattern is a behavioral software design
+> pattern that allows an object to alter its behavior
+> when its internal state changes. This pattern is
+> close to the concept of finite-state machines. The
+> state pattern can be interpreted as a strategy
+> pattern, which is able to switch a strategy through
+> invocations of methods defined in the pattern's
+> interface.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Mammoth
+    participant PeacefulState
+    participant AngryState
+
+    Client->>Mammoth: observe()
+    Mammoth->>PeacefulState: observe()
+    PeacefulState-->>Mammoth: "calm and peaceful"
+    Client->>Mammoth: timePasses()
+    Mammoth->>AngryState: onEnterState()
+    AngryState-->>Mammoth: "gets angry"
+    Client->>Mammoth: observe()
+    Mammoth->>AngryState: observe()
+    AngryState-->>Mammoth: "is furious"
+```
+
+### **Programmatic Example**
+
+In our example there is a mammoth with alternating
+moods. First, here is the state interface and its
+concrete implementations.
+
+```kotlin
+internal interface State {
+    fun onEnterState()
+    fun observe()
+}
+
+internal class PeacefulState(
+    private val mammoth: Mammoth,
+) : State {
+    override fun observe() {
+        logger.info("$mammoth is calm and peaceful.")
+    }
+
+    override fun onEnterState() {
+        logger.info("$mammoth calms down.")
+    }
+}
+
+internal class AngryState(
+    private val mammoth: Mammoth,
+) : State {
+    override fun observe() {
+        logger.info("$mammoth is furious!")
+    }
+
+    override fun onEnterState() {
+        logger.info("$mammoth gets angry!")
+    }
+}
+```
+
+And here is the mammoth containing the state. The
+state changes via calls to the `timePasses` method.
+
+```kotlin
+internal class Mammoth {
+    private var state: State = PeacefulState(this)
+
+    fun timePasses() {
+        val newState = when (state) {
+            is PeacefulState -> AngryState(this)
+            else -> PeacefulState(this)
+        }
+        changeStateTo(newState)
+    }
+
+    fun observe() {
+        state.observe()
+    }
+
+    private fun changeStateTo(newState: State) {
+        state = newState
+        state.onEnterState()
+    }
+
+    override fun toString() = "The mammoth"
+}
+```
+
+Here is how the mammoth behaves over time.
+
+```kotlin
+val mammoth = Mammoth()
+mammoth.observe()
+mammoth.timePasses()
+mammoth.observe()
+mammoth.timePasses()
+mammoth.observe()
+```
+
+Program output:
+
+```text
+The mammoth is calm and peaceful.
+The mammoth gets angry!
+The mammoth is furious!
+The mammoth calms down.
+The mammoth is calm and peaceful.
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class State {
+        <<interface>>
+        +onEnterState()
+        +observe()
+    }
+    class PeacefulState {
+        -mammoth Mammoth
+        +onEnterState()
+        +observe()
+    }
+    class AngryState {
+        -mammoth Mammoth
+        +onEnterState()
+        +observe()
+    }
+    class Mammoth {
+        -state State
+        +timePasses()
+        +observe()
+        +toString() String
+    }
+    Mammoth --> State : state
+    PeacefulState ..|> State
+    AngryState ..|> State
+    PeacefulState --> Mammoth : mammoth
+    AngryState --> Mammoth : mammoth
+```
+
+## Applicability
+
+Use the State pattern when:
+
+- An object's behavior depends on its state, and it
+  must change its behavior at runtime depending on
+  that state.
+- Operations have large, multipart conditional
+  statements that depend on the object's state.
+
+## Consequences
+
+Benefits:
+
+- Localizes state-specific behavior and partitions
+  behavior for different states.
+- Makes state transitions explicit.
+- State objects can be shared if they carry no
+  instance variables.
+
+Trade-offs:
+
+- Can result in a large number of state classes.
+- Context class can become complicated with transition
+  logic.
+
+## Related Patterns
+
+- [Strategy](../strategy/README.md): Both patterns
+  have similar structures, but Strategy lets you choose
+  an algorithm while State changes behavior based on
+  internal state.
+- [Flyweight](../flyweight/README.md): State objects
+  may be shared between contexts using Flyweight.
+- [Singleton](../singleton/README.md): State objects
+  are often singletons.
+
+## Credits
+
+- [Design Patterns: Elements of Reusable Object-Oriented
+  Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible and
+  Maintainable Object-Oriented
+  Software](https://amzn.to/49NGldq)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/state/build.gradle.kts
+++ b/state/build.gradle.kts
@@ -2,9 +2,20 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply true
 }
 
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/yonatankarp/kotlin-junit-tools")
+        credentials {
+            username = project.findProperty("gpr.user")?.toString() ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key")?.toString() ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
 dependencies {
     implementation(libs.bundles.kotlin.all)
     implementation(libs.bundles.log.all)
+    testImplementation(libs.kotlin.junit.tools)
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.tests.all)
 }

--- a/state/src/main/kotlin/com/yonatankarp/state/AngryState.kt
+++ b/state/src/main/kotlin/com/yonatankarp/state/AngryState.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.state
+
+/**
+ * [State] in which the [Mammoth] is angry and furious.
+ */
+internal class AngryState(private val mammoth: Mammoth) : State {
+    override fun observe() {
+        logger.info("$mammoth is furious!")
+    }
+
+    override fun onEnterState() {
+        logger.info("$mammoth gets angry!")
+    }
+}

--- a/state/src/main/kotlin/com/yonatankarp/state/App.kt
+++ b/state/src/main/kotlin/com/yonatankarp/state/App.kt
@@ -1,0 +1,17 @@
+package com.yonatankarp.state
+
+import org.slf4j.LoggerFactory
+
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.state")
+
+/**
+ * Program entry point.
+ */
+fun main() {
+    val mammoth = Mammoth()
+    mammoth.observe()
+    mammoth.timePasses()
+    mammoth.observe()
+    mammoth.timePasses()
+    mammoth.observe()
+}

--- a/state/src/main/kotlin/com/yonatankarp/state/Mammoth.kt
+++ b/state/src/main/kotlin/com/yonatankarp/state/Mammoth.kt
@@ -1,0 +1,37 @@
+package com.yonatankarp.state
+
+/**
+ * Context whose behavior changes based on its internal [State].
+ *
+ * The mammoth alternates between [PeacefulState] and
+ * [AngryState] as time passes.
+ */
+internal class Mammoth {
+    private var state: State = PeacefulState(this)
+
+    /**
+     * Advances time, toggling the mammoth's mood between
+     * peaceful and angry.
+     */
+    fun timePasses() {
+        val newState = when (state) {
+            is PeacefulState -> AngryState(this)
+            else -> PeacefulState(this)
+        }
+        changeStateTo(newState)
+    }
+
+    /**
+     * Observes the mammoth's current behavior.
+     */
+    fun observe() {
+        state.observe()
+    }
+
+    private fun changeStateTo(newState: State) {
+        state = newState
+        state.onEnterState()
+    }
+
+    override fun toString() = "The mammoth"
+}

--- a/state/src/main/kotlin/com/yonatankarp/state/PeacefulState.kt
+++ b/state/src/main/kotlin/com/yonatankarp/state/PeacefulState.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.state
+
+/**
+ * [State] in which the [Mammoth] is calm and peaceful.
+ */
+internal class PeacefulState(private val mammoth: Mammoth) : State {
+    override fun observe() {
+        logger.info("$mammoth is calm and peaceful.")
+    }
+
+    override fun onEnterState() {
+        logger.info("$mammoth calms down.")
+    }
+}

--- a/state/src/main/kotlin/com/yonatankarp/state/State.kt
+++ b/state/src/main/kotlin/com/yonatankarp/state/State.kt
@@ -1,0 +1,17 @@
+package com.yonatankarp.state
+
+/**
+ * Defines the behavior associated with a particular state
+ * of the [Mammoth].
+ */
+internal interface State {
+    /**
+     * Called when the [Mammoth] transitions into this state.
+     */
+    fun onEnterState()
+
+    /**
+     * Observes the [Mammoth] in this state.
+     */
+    fun observe()
+}

--- a/state/src/test/kotlin/com/yonatankarp/state/AppTest.kt
+++ b/state/src/test/kotlin/com/yonatankarp/state/AppTest.kt
@@ -1,0 +1,9 @@
+package com.yonatankarp.state
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+internal class AppTest {
+    @Test
+    fun `should execute without exception`() = assertDoesNotThrow { main() }
+}

--- a/state/src/test/kotlin/com/yonatankarp/state/MammothTest.kt
+++ b/state/src/test/kotlin/com/yonatankarp/state/MammothTest.kt
@@ -1,0 +1,81 @@
+package com.yonatankarp.state
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that the [Mammoth] alternates between
+ * peaceful and angry states as time passes.
+ */
+internal class MammothTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @Test
+    fun `should cycle through peaceful and angry states`() {
+        // Given
+        val mammoth = Mammoth()
+
+        // When — observe peaceful state
+        mammoth.observe()
+
+        // Then
+        assertEquals(
+            "The mammoth is calm and peaceful.",
+            appender.lastMessage
+        )
+        assertEquals(1, appender.logSize)
+
+        // When — time passes → angry
+        mammoth.timePasses()
+
+        // Then
+        assertEquals("The mammoth gets angry!", appender.lastMessage)
+        assertEquals(2, appender.logSize)
+
+        // When — observe angry state
+        mammoth.observe()
+
+        // Then
+        assertEquals("The mammoth is furious!", appender.lastMessage)
+        assertEquals(3, appender.logSize)
+
+        // When — time passes → peaceful again
+        mammoth.timePasses()
+
+        // Then
+        assertEquals("The mammoth calms down.", appender.lastMessage)
+        assertEquals(4, appender.logSize)
+
+        // When — observe peaceful state again
+        mammoth.observe()
+
+        // Then
+        assertEquals(
+            "The mammoth is calm and peaceful.",
+            appender.lastMessage
+        )
+        assertEquals(5, appender.logSize)
+    }
+
+    @Test
+    fun `should have meaningful toString`() {
+        val toString = Mammoth().toString()
+        assertNotNull(toString)
+        assertEquals("The mammoth", toString)
+    }
+}


### PR DESCRIPTION
Closes #405

## Description

Ports the State design pattern from the Java reference repo to idiomatic Kotlin.

### Main changes

- Implemented `State` interface with `PeacefulState` and `AngryState` concrete states
- Implemented `Mammoth` context class that alternates between states using `when`/`is` (replacing Java's `getClass().equals()`)
- Full test coverage: `AppTest` and `MammothTest` covering the complete state cycle
- README with Mermaid class and sequence diagrams, Consequences, Related Patterns
- All classes use `internal` visibility, KDoc with `[ClassName]` references
- Added `kotlin-junit-tools` dependency for `InMemoryLoggerAppender`

### Additional information

- Tags preserved from Java: Decoupling, Gang of Four, State tracking
- State already listed in `DESIGN_PATTERN_CATEGORIES.md` and `mkdocs.yml` (was an empty stub)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide to the State design pattern, covering intent, applicability, sequences, and practical examples.

* **New Features**
  * Added working example implementation of the State design pattern with state transition logic.

* **Tests**
  * Added test suite validating example behavior and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->