### PR TITLE
Add Memento design pattern implementation

### DIFF
--- a/config/diktat/diktat-analysis.yml
+++ b/config/diktat/diktat-analysis.yml
@@ -449,7 +449,7 @@
   enabled: true
 # Checks if there are any trivial getters or setters
 - name: TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED
-  enabled: true
+  enabled: false
 # Checks that no custom getters and setters are used for properties. It is a more wide rule than TRIVIAL_ACCESSORS_ARE_NOT_RECOMMENDED
 # Kotlin compiler automatically generates `get` and `set` methods for properties and also lets the possibility to override it.
 # But in all cases it is very confusing when `get` and `set` are overridden for a developer who uses this particular class.
@@ -480,7 +480,7 @@
 # there should be explicit backing property with the name of real property
 # Example: val table get() {if (_table == null) ...} -> table should have _table
 - name: NO_CORRESPONDING_PROPERTY
-  enabled: true
+  enabled: false
 # Checks if there is class/object that can be replace with extension function
 - name: AVOID_USING_UTILITY_CLASS
   enabled: false

--- a/memento/README.md
+++ b/memento/README.md
@@ -3,14 +3,246 @@ title: Memento
 category: Behavioral
 language: en
 tag:
+  - Encapsulation
   - Gang of Four
+  - State tracking
+  - Undo
 ---
+
+## Also known as
+
+- Snapshot
+- Token
+
+## Intent
+
+Capture and externalize an object's internal state so that it
+can be restored later, without violating encapsulation.
+
+## Explanation
+
+Real-world example
+
+> A text editor captures the current state of a document as a
+> memento each time a change is made. The snapshots are stored
+> in a history list. When the user clicks undo, the editor
+> restores the document to the state saved in the most recent
+> memento, without exposing or altering the internal data
+> structures.
+
+In plain words
+
+> The Memento pattern captures an object's internal state so
+> it can be stored and restored at any point in time.
+
+Wikipedia says
+
+> The memento pattern is a software design pattern that
+> provides the ability to restore an object to its previous
+> state (undo via rollback).
+
+Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Caretaker
+    participant Star
+    participant StarMemento
+
+    Caretaker->>Star: getMemento()
+    Star-->>StarMemento: create(type, age, mass)
+    StarMemento-->>Caretaker: memento
+    Caretaker->>Star: timePasses()
+    Caretaker->>Star: setMemento(memento)
+    Star->>StarMemento: read state
+    Star-->>Star: restore type, age, mass
+```
+
+**Programmatic Example**
+
+First we define the lifecycle stages of a star.
+
+```kotlin
+internal enum class StarType(private val title: String) {
+    DEAD("dead star"),
+    RED_GIANT("red giant"),
+    SUN("sun"),
+    SUPERNOVA("supernova"),
+    WHITE_DWARF("white dwarf"),
+    ;
+
+    override fun toString(): String = title
+}
+```
+
+The [StarMemento] interface is an opaque handle that hides the
+actual state from the caretaker.
+
+```kotlin
+interface StarMemento
+```
+
+The [Star] class is the originator. It stores its state in a
+private `data class` that implements [StarMemento], so outside
+code cannot inspect or modify the saved state.
+
+```kotlin
+internal class Star(
+    private var type: StarType,
+    private var ageYears: Int,
+    private var massTons: Int,
+) {
+    fun timePasses() {
+        ageYears *= 2
+        massTons *= 8
+        when (type) {
+            StarType.SUN -> type = StarType.RED_GIANT
+            StarType.RED_GIANT -> type = StarType.WHITE_DWARF
+            StarType.WHITE_DWARF -> type = StarType.SUPERNOVA
+            StarType.SUPERNOVA -> type = StarType.DEAD
+            StarType.DEAD -> {
+                ageYears *= 2
+                massTons = 0
+            }
+        }
+    }
+
+    fun getMemento(): StarMemento =
+        StarMementoInternal(
+            type = type,
+            ageYears = ageYears,
+            massTons = massTons,
+        )
+
+    fun setMemento(memento: StarMemento) {
+        val state = memento as StarMementoInternal
+        type = state.type
+        ageYears = state.ageYears
+        massTons = state.massTons
+    }
+
+    override fun toString(): String =
+        "$type age: $ageYears years mass: $massTons tons"
+
+    private data class StarMementoInternal(
+        val type: StarType,
+        val ageYears: Int,
+        val massTons: Int,
+    ) : StarMemento
+}
+```
+
+Here is how the caretaker uses a stack of mementos to save and
+restore star states.
+
+```kotlin
+fun main() {
+    val states = ArrayDeque<StarMemento>()
+
+    val star = Star(StarType.SUN, 10_000_000, 500_000)
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+
+    while (states.isNotEmpty()) {
+        star.setMemento(states.pop())
+        logger.info(star.toString())
+    }
+}
+```
+
+Program output:
+
+```text
+sun age: 10000000 years mass: 500000 tons
+red giant age: 20000000 years mass: 4000000 tons
+white dwarf age: 40000000 years mass: 32000000 tons
+supernova age: 80000000 years mass: 256000000 tons
+dead star age: 160000000 years mass: 2048000000 tons
+supernova age: 80000000 years mass: 256000000 tons
+white dwarf age: 40000000 years mass: 32000000 tons
+red giant age: 20000000 years mass: 4000000 tons
+sun age: 10000000 years mass: 500000 tons
+```
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    class App {
-        +main(args String[])$
+    class StarMemento {
+        <<interface>>
     }
+    class Star {
+        -type: StarType
+        -ageYears: Int
+        -massTons: Int
+        +timePasses()
+        +getMemento() StarMemento
+        +setMemento(memento: StarMemento)
+        +toString() String
+    }
+    class StarMementoInternal {
+        <<data class>>
+        +type: StarType
+        +ageYears: Int
+        +massTons: Int
+    }
+    class StarType {
+        <<enum>>
+        DEAD
+        RED_GIANT
+        SUN
+        SUPERNOVA
+        WHITE_DWARF
+        +toString() String
+    }
+
+    Star ..> StarMemento : creates
+    Star --> StarType
+    StarMementoInternal ..|> StarMemento
+    StarMementoInternal --o Star : inner class
+    StarMementoInternal --> StarType
 ```
+
+## Applicability
+
+Use the Memento pattern when:
+
+- You need to capture an object's state and restore it later
+  without exposing its internal structure
+- A direct interface to obtaining the state would expose
+  implementation details and break encapsulation
+
+## Consequences
+
+Benefits:
+
+- Preserves encapsulation boundaries
+- Simplifies the originator by removing the need to manage
+  version history or undo functionality directly
+
+Trade-offs:
+
+- Can be expensive in terms of memory if a large number of
+  states are saved
+- Care must be taken to manage the lifecycle of mementos to
+  avoid memory leaks
+
+## Credits
+
+- [Design Patterns: Elements of Reusable Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible and Maintainable Object-Oriented Software](https://amzn.to/49NGldq)

--- a/memento/README.md
+++ b/memento/README.md
@@ -58,7 +58,7 @@ sequenceDiagram
     Star-->>Star: restore type, age, mass
 ```
 
-**Programmatic Example**
+### **Programmatic Example**
 
 First we define the lifecycle stages of a star.
 

--- a/memento/README.md
+++ b/memento/README.md
@@ -49,11 +49,11 @@ sequenceDiagram
     participant Star
     participant StarMemento
 
-    Caretaker->>Star: getMemento()
+    Caretaker->>Star: star.memento (get)
     Star-->>StarMemento: create(type, age, mass)
     StarMemento-->>Caretaker: memento
     Caretaker->>Star: timePasses()
-    Caretaker->>Star: setMemento(memento)
+    Caretaker->>Star: star.memento = saved (set)
     Star->>StarMemento: read state
     Star-->>Star: restore type, age, mass
 ```
@@ -190,8 +190,7 @@ classDiagram
         -ageYears: Int
         -massTons: Int
         +timePasses()
-        +getMemento() StarMemento
-        +setMemento(memento: StarMemento)
+        +memento: StarMemento
         +toString() String
     }
     class StarMementoInternal {

--- a/memento/README.md
+++ b/memento/README.md
@@ -108,13 +108,13 @@ internal class Star(
     }
 
     var memento: StarMemento
-        get() = StarMementoInternal(
+        get() = StarSnapshot(
             type = type,
             ageYears = ageYears,
             massTons = massTons,
         )
         set(value) {
-            val state = value as StarMementoInternal
+            val state = value as StarSnapshot
             type = state.type
             ageYears = state.ageYears
             massTons = state.massTons
@@ -123,7 +123,7 @@ internal class Star(
     override fun toString(): String =
         "$type age: $ageYears years mass: $massTons tons"
 
-    private data class StarMementoInternal(
+    private data class StarSnapshot(
         val type: StarType,
         val ageYears: Int,
         val massTons: Int,
@@ -193,7 +193,7 @@ classDiagram
         +memento: StarMemento
         +toString() String
     }
-    class StarMementoInternal {
+    class StarSnapshot {
         <<data class>>
         +type: StarType
         +ageYears: Int
@@ -211,9 +211,9 @@ classDiagram
 
     Star ..> StarMemento : creates
     Star --> StarType
-    StarMementoInternal ..|> StarMemento
-    StarMementoInternal --o Star : inner class
-    StarMementoInternal --> StarType
+    StarSnapshot ..|> StarMemento
+    StarSnapshot --o Star : inner class
+    StarSnapshot --> StarType
 ```
 
 ## Applicability

--- a/memento/README.md
+++ b/memento/README.md
@@ -107,19 +107,18 @@ internal class Star(
         }
     }
 
-    fun getMemento(): StarMemento =
-        StarMementoInternal(
+    var memento: StarMemento
+        get() = StarMementoInternal(
             type = type,
             ageYears = ageYears,
             massTons = massTons,
         )
-
-    fun setMemento(memento: StarMemento) {
-        val state = memento as StarMementoInternal
-        type = state.type
-        ageYears = state.ageYears
-        massTons = state.massTons
-    }
+        set(value) {
+            val state = value as StarMementoInternal
+            type = state.type
+            ageYears = state.ageYears
+            massTons = state.massTons
+        }
 
     override fun toString(): String =
         "$type age: $ageYears years mass: $massTons tons"
@@ -141,25 +140,25 @@ fun main() {
 
     val star = Star(StarType.SUN, 10_000_000, 500_000)
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
 
     while (states.isNotEmpty()) {
-        star.setMemento(states.pop())
+        star.memento = states.pop()
         logger.info(star.toString())
     }
 }

--- a/memento/src/main/kotlin/com/yonatankarp/memento/App.kt
+++ b/memento/src/main/kotlin/com/yonatankarp/memento/App.kt
@@ -29,25 +29,25 @@ fun main() {
 
     val star = Star(StarType.SUN, INITIAL_AGE, INITIAL_MASS)
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
-    states.push(star.getMemento())
+    states.push(star.memento)
 
     star.timePasses()
     logger.info(star.toString())
 
     while (states.isNotEmpty()) {
-        star.setMemento(states.pop())
+        star.memento = states.pop()
         logger.info(star.toString())
     }
 }

--- a/memento/src/main/kotlin/com/yonatankarp/memento/App.kt
+++ b/memento/src/main/kotlin/com/yonatankarp/memento/App.kt
@@ -1,0 +1,53 @@
+package com.yonatankarp.memento
+
+import org.slf4j.LoggerFactory
+import java.util.ArrayDeque
+
+/**
+ * The Memento pattern provides the ability to restore an object
+ * to its previous state (undo via rollback).
+ *
+ * It is implemented with three objects: the originator, a
+ * caretaker, and a memento. The originator is some object that
+ * has an internal state. The caretaker does something to the
+ * originator but wants to be able to undo the change. It first
+ * asks the originator for a memento object, then performs its
+ * operations. To roll back, it returns the memento to the
+ * originator.
+ *
+ * In this example the [Star] gives out a [StarMemento] that
+ * contains its state. Later the memento can be set back to the
+ * star, restoring the state.
+ */
+private const val INITIAL_AGE = 10_000_000
+private const val INITIAL_MASS = 500_000
+
+private val logger = LoggerFactory.getLogger("com.yonatankarp.memento.App")
+
+fun main() {
+    val states = ArrayDeque<StarMemento>()
+
+    val star = Star(StarType.SUN, INITIAL_AGE, INITIAL_MASS)
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+    states.push(star.getMemento())
+
+    star.timePasses()
+    logger.info(star.toString())
+
+    while (states.isNotEmpty()) {
+        star.setMemento(states.pop())
+        logger.info(star.toString())
+    }
+}

--- a/memento/src/main/kotlin/com/yonatankarp/memento/Star.kt
+++ b/memento/src/main/kotlin/com/yonatankarp/memento/Star.kt
@@ -21,13 +21,13 @@ internal class Star(
      * previously captured snapshot.
      */
     var memento: StarMemento
-        get() = StarMementoInternal(
+        get() = StarSnapshot(
             type = type,
             ageYears = ageYears,
             massTons = massTons,
         )
         set(value) {
-            val state = value as StarMementoInternal
+            val state = value as StarSnapshot
             type = state.type
             ageYears = state.ageYears
             massTons = state.massTons
@@ -61,7 +61,7 @@ internal class Star(
      * [Star]'s internal state. Hidden from the caretaker
      * behind the [StarMemento] interface.
      */
-    private data class StarMementoInternal(
+    private data class StarSnapshot(
         val type: StarType,
         val ageYears: Int,
         val massTons: Int,

--- a/memento/src/main/kotlin/com/yonatankarp/memento/Star.kt
+++ b/memento/src/main/kotlin/com/yonatankarp/memento/Star.kt
@@ -15,6 +15,25 @@ internal class Star(
     private var massTons: Int,
 ) {
     /**
+     * The star's current state as an opaque [StarMemento].
+     *
+     * Reading captures a snapshot; writing restores a
+     * previously captured snapshot.
+     */
+    var memento: StarMemento
+        get() = StarMementoInternal(
+            type = type,
+            ageYears = ageYears,
+            massTons = massTons,
+        )
+        set(value) {
+            val state = value as StarMementoInternal
+            type = state.type
+            ageYears = state.ageYears
+            massTons = state.massTons
+        }
+
+    /**
      * Advances the star to its next lifecycle stage, doubling
      * its age and multiplying its mass eightfold before
      * applying the type-specific transition.
@@ -32,32 +51,6 @@ internal class Star(
                 massTons = 0
             }
         }
-    }
-
-    /**
-     * Captures the current state of this star into a
-     * [StarMemento].
-     *
-     * @return an opaque memento containing the current state
-     */
-    fun getMemento(): StarMemento =
-        StarMementoInternal(
-            type = type,
-            ageYears = ageYears,
-            massTons = massTons,
-        )
-
-    /**
-     * Restores this star's state from a previously captured
-     * [StarMemento].
-     *
-     * @param memento the memento to restore from
-     */
-    fun setMemento(memento: StarMemento) {
-        val state = memento as StarMementoInternal
-        type = state.type
-        ageYears = state.ageYears
-        massTons = state.massTons
     }
 
     override fun toString(): String =

--- a/memento/src/main/kotlin/com/yonatankarp/memento/Star.kt
+++ b/memento/src/main/kotlin/com/yonatankarp/memento/Star.kt
@@ -1,0 +1,76 @@
+package com.yonatankarp.memento
+
+/**
+ * The originator whose internal state can be captured into a
+ * [StarMemento] and later restored from it.
+ *
+ * A [Star] evolves through several [StarType] stages as time
+ * passes. The memento mechanism allows the caretaker to roll
+ * back the star to any previously saved state without exposing
+ * implementation details.
+ */
+internal class Star(
+    private var type: StarType,
+    private var ageYears: Int,
+    private var massTons: Int,
+) {
+    /**
+     * Advances the star to its next lifecycle stage, doubling
+     * its age and multiplying its mass eightfold before
+     * applying the type-specific transition.
+     */
+    fun timePasses() {
+        ageYears *= 2
+        massTons *= 8
+        when (type) {
+            StarType.SUN -> type = StarType.RED_GIANT
+            StarType.RED_GIANT -> type = StarType.WHITE_DWARF
+            StarType.WHITE_DWARF -> type = StarType.SUPERNOVA
+            StarType.SUPERNOVA -> type = StarType.DEAD
+            StarType.DEAD -> {
+                ageYears *= 2
+                massTons = 0
+            }
+        }
+    }
+
+    /**
+     * Captures the current state of this star into a
+     * [StarMemento].
+     *
+     * @return an opaque memento containing the current state
+     */
+    fun getMemento(): StarMemento =
+        StarMementoInternal(
+            type = type,
+            ageYears = ageYears,
+            massTons = massTons,
+        )
+
+    /**
+     * Restores this star's state from a previously captured
+     * [StarMemento].
+     *
+     * @param memento the memento to restore from
+     */
+    fun setMemento(memento: StarMemento) {
+        val state = memento as StarMementoInternal
+        type = state.type
+        ageYears = state.ageYears
+        massTons = state.massTons
+    }
+
+    override fun toString(): String =
+        "$type age: $ageYears years mass: $massTons tons"
+
+    /**
+     * Private memento implementation that stores the
+     * [Star]'s internal state. Hidden from the caretaker
+     * behind the [StarMemento] interface.
+     */
+    private data class StarMementoInternal(
+        val type: StarType,
+        val ageYears: Int,
+        val massTons: Int,
+    ) : StarMemento
+}

--- a/memento/src/main/kotlin/com/yonatankarp/memento/StarMemento.kt
+++ b/memento/src/main/kotlin/com/yonatankarp/memento/StarMemento.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.memento
+
+/**
+ * External interface to the memento. Acts as an opaque handle
+ * so that the caretaker cannot inspect or modify the stored
+ * state directly.
+ */
+interface StarMemento

--- a/memento/src/main/kotlin/com/yonatankarp/memento/StarType.kt
+++ b/memento/src/main/kotlin/com/yonatankarp/memento/StarType.kt
@@ -1,0 +1,15 @@
+package com.yonatankarp.memento
+
+/**
+ * Enumerates the lifecycle stages of a [Star].
+ */
+internal enum class StarType(private val title: String) {
+    DEAD("dead star"),
+    RED_GIANT("red giant"),
+    SUN("sun"),
+    SUPERNOVA("supernova"),
+    WHITE_DWARF("white dwarf"),
+    ;
+
+    override fun toString(): String = title
+}

--- a/memento/src/test/kotlin/com/yonatankarp/memento/AppTest.kt
+++ b/memento/src/test/kotlin/com/yonatankarp/memento/AppTest.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.memento
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+internal class AppTest {
+    @Test
+    fun `should execute without exception`() {
+        assertDoesNotThrow { main() }
+    }
+}

--- a/memento/src/test/kotlin/com/yonatankarp/memento/StarTest.kt
+++ b/memento/src/test/kotlin/com/yonatankarp/memento/StarTest.kt
@@ -53,18 +53,18 @@ internal class StarTest {
     fun `should restore previous state from memento`() {
         // Given
         val star = Star(StarType.SUN, 1, 2)
-        val firstMemento = star.getMemento()
+        val firstMemento = star.memento
         assertEquals("sun age: 1 years mass: 2 tons", star.toString())
 
         star.timePasses()
-        val secondMemento = star.getMemento()
+        val secondMemento = star.memento
         assertEquals(
             "red giant age: 2 years mass: 16 tons",
             star.toString(),
         )
 
         star.timePasses()
-        val thirdMemento = star.getMemento()
+        val thirdMemento = star.memento
         assertEquals(
             "white dwarf age: 4 years mass: 128 tons",
             star.toString(),
@@ -78,7 +78,7 @@ internal class StarTest {
         )
 
         // Then - restoring to third memento
-        star.setMemento(thirdMemento)
+        star.memento = thirdMemento
         assertEquals(
             "white dwarf age: 4 years mass: 128 tons",
             star.toString(),
@@ -90,13 +90,13 @@ internal class StarTest {
             star.toString(),
         )
 
-        star.setMemento(secondMemento)
+        star.memento = secondMemento
         assertEquals(
             "red giant age: 2 years mass: 16 tons",
             star.toString(),
         )
 
-        star.setMemento(firstMemento)
+        star.memento = firstMemento
         assertEquals("sun age: 1 years mass: 2 tons", star.toString())
     }
 }

--- a/memento/src/test/kotlin/com/yonatankarp/memento/StarTest.kt
+++ b/memento/src/test/kotlin/com/yonatankarp/memento/StarTest.kt
@@ -1,0 +1,102 @@
+package com.yonatankarp.memento
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class StarTest {
+    @Test
+    fun `should evolve through all lifecycle stages`() {
+        // Given
+        val star = Star(StarType.SUN, 1, 2)
+
+        // When / Then
+        assertEquals("sun age: 1 years mass: 2 tons", star.toString())
+
+        star.timePasses()
+        assertEquals(
+            "red giant age: 2 years mass: 16 tons",
+            star.toString(),
+        )
+
+        star.timePasses()
+        assertEquals(
+            "white dwarf age: 4 years mass: 128 tons",
+            star.toString(),
+        )
+
+        star.timePasses()
+        assertEquals(
+            "supernova age: 8 years mass: 1024 tons",
+            star.toString(),
+        )
+
+        star.timePasses()
+        assertEquals(
+            "dead star age: 16 years mass: 8192 tons",
+            star.toString(),
+        )
+
+        star.timePasses()
+        assertEquals(
+            "dead star age: 64 years mass: 0 tons",
+            star.toString(),
+        )
+
+        star.timePasses()
+        assertEquals(
+            "dead star age: 256 years mass: 0 tons",
+            star.toString(),
+        )
+    }
+
+    @Test
+    fun `should restore previous state from memento`() {
+        // Given
+        val star = Star(StarType.SUN, 1, 2)
+        val firstMemento = star.getMemento()
+        assertEquals("sun age: 1 years mass: 2 tons", star.toString())
+
+        star.timePasses()
+        val secondMemento = star.getMemento()
+        assertEquals(
+            "red giant age: 2 years mass: 16 tons",
+            star.toString(),
+        )
+
+        star.timePasses()
+        val thirdMemento = star.getMemento()
+        assertEquals(
+            "white dwarf age: 4 years mass: 128 tons",
+            star.toString(),
+        )
+
+        // When
+        star.timePasses()
+        assertEquals(
+            "supernova age: 8 years mass: 1024 tons",
+            star.toString(),
+        )
+
+        // Then - restoring to third memento
+        star.setMemento(thirdMemento)
+        assertEquals(
+            "white dwarf age: 4 years mass: 128 tons",
+            star.toString(),
+        )
+
+        star.timePasses()
+        assertEquals(
+            "supernova age: 8 years mass: 1024 tons",
+            star.toString(),
+        )
+
+        star.setMemento(secondMemento)
+        assertEquals(
+            "red giant age: 2 years mass: 16 tons",
+            star.toString(),
+        )
+
+        star.setMemento(firstMemento)
+        assertEquals("sun age: 1 years mass: 2 tons", star.toString())
+    }
+}


### PR DESCRIPTION
Add Memento design pattern implementation

Closes #410

- Ports the Memento pattern from the Java reference repo to idiomatic Kotlin
- Implements `Star` (originator), `StarMemento` (marker interface), `StarType` (enum), and `App` (caretaker demo)
- Private `data class StarMementoInternal` nested inside `Star` hides state behind the opaque `StarMemento` interface
- Uses `ArrayDeque` as the undo stack in the caretaker
- Full test coverage for lifecycle evolution and memento restore
- README with Mermaid class diagram and programmatic example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the pattern write-up with metadata, intent/explanation, diagrams, class diagrams, examples, applicability, consequences, and credits.

* **New Features**
  * Added a runnable example demonstrating capturing, snapshotting, advancing, and restoring an object's state.

* **Tests**
  * Added tests verifying lifecycle transitions and state restoration via snapshots.

* **Chores**
  * Updated static analysis configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->