### PR TITLE
Add Command design pattern implementation

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -1,0 +1,310 @@
+---
+title: Command
+category: Behavioral
+language: en
+tag:
+  - Decoupling
+  - Extensibility
+  - Gang of Four
+  - Undo
+---
+
+## Also known as
+
+- Action
+- Transaction
+
+## Intent
+
+Encapsulate a request as an object, thereby letting you
+parameterize clients with different requests, queue or log
+requests, and support undoable operations.
+
+## Explanation
+
+Real-world example
+
+> Imagine a smart home system where you can control devices
+> such as lights, thermostats, and security cameras through a
+> central application. Each command to operate these devices is
+> encapsulated as an object, enabling the system to queue,
+> execute sequentially, and undo commands if necessary. This
+> approach decouples control logic from device implementation,
+> allowing easy addition of new devices or features without
+> altering the core application.
+
+In plain words
+
+> Storing requests as command objects allows performing an
+> action or undoing it at a later time.
+
+Wikipedia says
+
+> In object-oriented programming, the command pattern is a
+> behavioral design pattern in which an object is used to
+> encapsulate all information needed to perform an action or
+> trigger an event at a later time.
+
+Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Wizard
+    participant Goblin
+
+    Client->>Wizard: castSpell(goblin::changeSize)
+    Wizard->>Goblin: changeSize()
+    Wizard->>Wizard: push to undoStack
+
+    Client->>Wizard: undoLastSpell()
+    Wizard->>Wizard: pop from undoStack
+    Wizard->>Goblin: changeSize()
+    Wizard->>Wizard: push to redoStack
+
+    Client->>Wizard: redoLastSpell()
+    Wizard->>Wizard: pop from redoStack
+    Wizard->>Goblin: changeSize()
+    Wizard->>Wizard: push to undoStack
+```
+
+**Programmatic Example**
+
+In the Command pattern, objects are used to encapsulate all
+information needed to perform an action or trigger an event at
+a later time. This pattern is particularly useful for
+implementing undo functionality in applications.
+
+In our example, a `Wizard` casts spells on a `Goblin`. Each
+spell is a command object that can be executed and undone. The
+spells are executed on the goblin one by one. The first spell
+shrinks the goblin and the second makes him invisible. Then the
+wizard reverses the spells one by one.
+
+First, we have the `Size` and `Visibility` enumerations that
+define the target's state.
+
+```kotlin
+internal enum class Size {
+    NORMAL,
+    SMALL,
+    ;
+
+    override fun toString() = name.lowercase()
+}
+
+internal enum class Visibility {
+    INVISIBLE,
+    VISIBLE,
+    ;
+
+    override fun toString() = name.lowercase()
+}
+```
+
+`Target` is the abstract base class. A target has a `Size` and
+a `Visibility` that can be toggled.
+
+```kotlin
+internal abstract class Target(
+    var size: Size,
+    var visibility: Visibility,
+) {
+    fun printStatus() {
+        logger.info(
+            "{}, [size={}] [visibility={}]",
+            this,
+            size,
+            visibility,
+        )
+    }
+
+    fun changeSize() {
+        size =
+            if (size == Size.NORMAL) Size.SMALL else Size.NORMAL
+    }
+
+    fun changeVisibility() {
+        visibility =
+            if (visibility == Visibility.INVISIBLE) {
+                Visibility.VISIBLE
+            } else {
+                Visibility.INVISIBLE
+            }
+    }
+}
+```
+
+`Goblin` is the concrete target.
+
+```kotlin
+internal class Goblin : Target(
+    size = Size.NORMAL,
+    visibility = Visibility.VISIBLE,
+) {
+    override fun toString() = "Goblin"
+}
+```
+
+`Wizard` is the invoker. Commands are represented as simple
+`() -> Unit` lambdas. The wizard keeps an undo stack and a redo
+stack so that spells can be reversed and replayed.
+
+```kotlin
+internal class Wizard {
+    private val undoStack = ArrayDeque<() -> Unit>()
+    private val redoStack = ArrayDeque<() -> Unit>()
+
+    fun castSpell(spell: () -> Unit) {
+        spell()
+        undoStack.addLast(spell)
+    }
+
+    fun undoLastSpell() {
+        if (undoStack.isNotEmpty()) {
+            val previousSpell = undoStack.removeLast()
+            redoStack.addLast(previousSpell)
+            previousSpell()
+        }
+    }
+
+    fun redoLastSpell() {
+        if (redoStack.isNotEmpty()) {
+            val previousSpell = redoStack.removeLast()
+            undoStack.addLast(previousSpell)
+            previousSpell()
+        }
+    }
+
+    override fun toString() = "Wizard"
+}
+```
+
+Here is the full example of the wizard casting spells.
+
+```kotlin
+fun main() {
+    val wizard = Wizard()
+    val goblin = Goblin()
+
+    goblin.printStatus()
+
+    wizard.castSpell(goblin::changeSize)
+    goblin.printStatus()
+
+    wizard.castSpell(goblin::changeVisibility)
+    goblin.printStatus()
+
+    wizard.undoLastSpell()
+    goblin.printStatus()
+
+    wizard.undoLastSpell()
+    goblin.printStatus()
+
+    wizard.redoLastSpell()
+    goblin.printStatus()
+
+    wizard.redoLastSpell()
+    goblin.printStatus()
+}
+```
+
+Program output:
+
+```text
+Goblin, [size=normal] [visibility=visible]
+Goblin, [size=small] [visibility=visible]
+Goblin, [size=small] [visibility=invisible]
+Goblin, [size=small] [visibility=visible]
+Goblin, [size=normal] [visibility=visible]
+Goblin, [size=small] [visibility=visible]
+Goblin, [size=small] [visibility=invisible]
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class Target {
+        <<abstract>>
+        +size: Size
+        +visibility: Visibility
+        +printStatus()
+        +changeSize()
+        +changeVisibility()
+    }
+
+    class Goblin {
+        +toString(): String
+    }
+
+    class Wizard {
+        -undoStack: ArrayDeque~() -~ Unit~
+        -redoStack: ArrayDeque~() -~ Unit~
+        +castSpell(spell: () -~ Unit)
+        +undoLastSpell()
+        +redoLastSpell()
+        +toString(): String
+    }
+
+    class Size {
+        <<enumeration>>
+        NORMAL
+        SMALL
+        +toString(): String
+    }
+
+    class Visibility {
+        <<enumeration>>
+        INVISIBLE
+        VISIBLE
+        +toString(): String
+    }
+
+    Target <|-- Goblin
+    Target --> Size
+    Target --> Visibility
+    Wizard ..> Target : invokes commands on
+```
+
+## Applicability
+
+Use the Command pattern when you want to:
+
+- Parameterize objects with actions to perform, offering an
+  object-oriented alternative to callbacks. Commands can be
+  registered and executed later.
+- Specify, queue, and execute requests at different times,
+  allowing commands to exist independently of the original
+  request.
+- Support undo functionality, where the command's execute
+  operation stores state and includes an un-execute operation
+  to reverse previous actions.
+- Log changes to reapply them after a system crash by adding
+  load and store operations to the command interface.
+- Structure a system around high-level operations built on
+  primitive operations, which is common in transaction-based
+  systems.
+
+## Consequences
+
+Benefits:
+
+- Decouples the object that invokes the operation from the
+  one that knows how to perform it.
+- It is easy to add new commands because you do not have to
+  change existing classes.
+- You can assemble a set of commands into a composite command.
+
+Trade-offs:
+
+- Increases the number of classes for each individual command.
+- Can complicate the design by adding multiple layers between
+  senders and receivers.
+
+## Credits
+
+- [Design Patterns: Elements of Reusable Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible and Maintainable Object-Oriented Software](https://amzn.to/49NGldq)
+- [J2EE Design Patterns](https://amzn.to/4dpzgmx)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/command/README.md
+++ b/command/README.md
@@ -68,7 +68,7 @@ sequenceDiagram
     Wizard->>Wizard: push to undoStack
 ```
 
-**Programmatic Example**
+### **Programmatic Example**
 
 In the Command pattern, objects are used to encapsulate all
 information needed to perform an action or trigger an event at

--- a/command/README.md
+++ b/command/README.md
@@ -111,12 +111,7 @@ internal abstract class Target(
     var visibility: Visibility,
 ) {
     fun printStatus() {
-        logger.info(
-            "{}, [size={}] [visibility={}]",
-            this,
-            size,
-            visibility,
-        )
+        logger.info("$this, [size=$size] [visibility=$visibility]")
     }
 
     fun changeSize() {

--- a/command/src/main/kotlin/com/yonatankarp/command/App.kt
+++ b/command/src/main/kotlin/com/yonatankarp/command/App.kt
@@ -1,0 +1,44 @@
+package com.yonatankarp.command
+
+/**
+ * The Command pattern is a behavioral design pattern in which an
+ * object is used to encapsulate all information needed to perform
+ * an action or trigger an event at a later time.
+ *
+ * Four terms always associated with the command pattern are
+ * command, receiver, invoker and client. A command object (spell)
+ * knows about the receiver (target) and invokes a method of the
+ * receiver. An invoker object ([Wizard]) receives a reference to
+ * the command to be executed and optionally does bookkeeping about
+ * the command execution. The client decides which commands to
+ * execute at which points.
+ *
+ * In this example the wizard casts spells on the goblin. The
+ * wizard keeps track of the previous spells cast, so it is easy
+ * to undo them. In addition, the wizard keeps track of the spells
+ * undone, so they can be redone.
+ */
+fun main() {
+    val wizard = Wizard()
+    val goblin = Goblin()
+
+    goblin.printStatus()
+
+    wizard.castSpell(goblin::changeSize)
+    goblin.printStatus()
+
+    wizard.castSpell(goblin::changeVisibility)
+    goblin.printStatus()
+
+    wizard.undoLastSpell()
+    goblin.printStatus()
+
+    wizard.undoLastSpell()
+    goblin.printStatus()
+
+    wizard.redoLastSpell()
+    goblin.printStatus()
+
+    wizard.redoLastSpell()
+    goblin.printStatus()
+}

--- a/command/src/main/kotlin/com/yonatankarp/command/Goblin.kt
+++ b/command/src/main/kotlin/com/yonatankarp/command/Goblin.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.command
+
+/**
+ * A goblin is the target of the wizard's spells.
+ */
+internal class Goblin : Target(
+    size = Size.NORMAL,
+    visibility = Visibility.VISIBLE,
+) {
+    override fun toString() = "Goblin"
+}

--- a/command/src/main/kotlin/com/yonatankarp/command/Size.kt
+++ b/command/src/main/kotlin/com/yonatankarp/command/Size.kt
@@ -1,0 +1,12 @@
+package com.yonatankarp.command
+
+/**
+ * Enumeration for target size.
+ */
+internal enum class Size {
+    NORMAL,
+    SMALL,
+    ;
+
+    override fun toString() = name.lowercase()
+}

--- a/command/src/main/kotlin/com/yonatankarp/command/Target.kt
+++ b/command/src/main/kotlin/com/yonatankarp/command/Target.kt
@@ -1,0 +1,52 @@
+package com.yonatankarp.command
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+internal val logger: Logger =
+    LoggerFactory.getLogger("com.yonatankarp.command")
+
+/**
+ * Base class for spell targets.
+ *
+ * A target has a [Size] and a [Visibility] that can be toggled
+ * by invoking [changeSize] or [changeVisibility].
+ */
+internal open class Target(
+    var size: Size,
+    var visibility: Visibility,
+) {
+    /**
+     * Logs the current status of this target.
+     */
+    fun printStatus() {
+        logger.info(
+            "{}, [size={}] [visibility={}]",
+            this,
+            size,
+            visibility,
+        )
+    }
+
+    /**
+     * Toggles the size of this target between [Size.NORMAL]
+     * and [Size.SMALL].
+     */
+    fun changeSize() {
+        size =
+            if (size == Size.NORMAL) Size.SMALL else Size.NORMAL
+    }
+
+    /**
+     * Toggles the visibility of this target between
+     * [Visibility.VISIBLE] and [Visibility.INVISIBLE].
+     */
+    fun changeVisibility() {
+        visibility =
+            if (visibility == Visibility.INVISIBLE) {
+                Visibility.VISIBLE
+            } else {
+                Visibility.INVISIBLE
+            }
+    }
+}

--- a/command/src/main/kotlin/com/yonatankarp/command/Target.kt
+++ b/command/src/main/kotlin/com/yonatankarp/command/Target.kt
@@ -20,12 +20,7 @@ internal open class Target(
      * Logs the current status of this target.
      */
     fun printStatus() {
-        logger.info(
-            "{}, [size={}] [visibility={}]",
-            this,
-            size,
-            visibility,
-        )
+        logger.info("$this, [size=$size] [visibility=$visibility]")
     }
 
     /**

--- a/command/src/main/kotlin/com/yonatankarp/command/Visibility.kt
+++ b/command/src/main/kotlin/com/yonatankarp/command/Visibility.kt
@@ -1,0 +1,12 @@
+package com.yonatankarp.command
+
+/**
+ * Enumeration for target visibility.
+ */
+internal enum class Visibility {
+    INVISIBLE,
+    VISIBLE,
+    ;
+
+    override fun toString() = name.lowercase()
+}

--- a/command/src/main/kotlin/com/yonatankarp/command/Wizard.kt
+++ b/command/src/main/kotlin/com/yonatankarp/command/Wizard.kt
@@ -1,0 +1,49 @@
+package com.yonatankarp.command
+
+import java.util.ArrayDeque
+
+/**
+ * The wizard is the invoker of the commands.
+ *
+ * Commands are represented as simple [() -> Unit][Function0] lambdas
+ * (equivalent to Java's [Runnable]). The wizard keeps an undo stack
+ * and a redo stack so that spells can be reversed and replayed.
+ */
+internal class Wizard {
+    private val undoStack = ArrayDeque<() -> Unit>()
+    private val redoStack = ArrayDeque<() -> Unit>()
+
+    /**
+     * Casts the given [spell] and pushes it onto the undo stack.
+     */
+    fun castSpell(spell: () -> Unit) {
+        spell()
+        undoStack.addLast(spell)
+    }
+
+    /**
+     * Undoes the last spell by re-executing it (toggle behaviour)
+     * and moves it to the redo stack.
+     */
+    fun undoLastSpell() {
+        if (undoStack.isNotEmpty()) {
+            val previousSpell = undoStack.removeLast()
+            redoStack.addLast(previousSpell)
+            previousSpell()
+        }
+    }
+
+    /**
+     * Redoes the last undone spell and moves it back to the
+     * undo stack.
+     */
+    fun redoLastSpell() {
+        if (redoStack.isNotEmpty()) {
+            val previousSpell = redoStack.removeLast()
+            undoStack.addLast(previousSpell)
+            previousSpell()
+        }
+    }
+
+    override fun toString() = "Wizard"
+}

--- a/command/src/test/kotlin/com/yonatankarp/command/AppTest.kt
+++ b/command/src/test/kotlin/com/yonatankarp/command/AppTest.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.command
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests that the Command example runs without errors.
+ */
+internal class AppTest {
+    @Test
+    fun `should execute application without exception`() {
+        assertDoesNotThrow { main() }
+    }
+}

--- a/command/src/test/kotlin/com/yonatankarp/command/CommandTest.kt
+++ b/command/src/test/kotlin/com/yonatankarp/command/CommandTest.kt
@@ -1,0 +1,140 @@
+package com.yonatankarp.command
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that the [Wizard] can cast, undo, and redo spells
+ * on a [Goblin] target.
+ */
+internal class CommandTest {
+    @Test
+    fun `should cast spell and change goblin size`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+
+        // When
+        wizard.castSpell(goblin::changeSize)
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.SMALL, Visibility.VISIBLE)
+    }
+
+    @Test
+    fun `should cast spell and change goblin visibility`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+        wizard.castSpell(goblin::changeSize)
+
+        // When
+        wizard.castSpell(goblin::changeVisibility)
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.SMALL, Visibility.INVISIBLE)
+    }
+
+    @Test
+    fun `should undo last spell`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+        wizard.castSpell(goblin::changeSize)
+        wizard.castSpell(goblin::changeVisibility)
+
+        // When
+        wizard.undoLastSpell()
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.SMALL, Visibility.VISIBLE)
+    }
+
+    @Test
+    fun `should undo all spells`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+        wizard.castSpell(goblin::changeSize)
+        wizard.castSpell(goblin::changeVisibility)
+
+        // When
+        wizard.undoLastSpell()
+        wizard.undoLastSpell()
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.NORMAL, Visibility.VISIBLE)
+    }
+
+    @Test
+    fun `should redo last spell`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+        wizard.castSpell(goblin::changeSize)
+        wizard.castSpell(goblin::changeVisibility)
+        wizard.undoLastSpell()
+        wizard.undoLastSpell()
+
+        // When
+        wizard.redoLastSpell()
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.SMALL, Visibility.VISIBLE)
+    }
+
+    @Test
+    fun `should redo all spells`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+        wizard.castSpell(goblin::changeSize)
+        wizard.castSpell(goblin::changeVisibility)
+        wizard.undoLastSpell()
+        wizard.undoLastSpell()
+
+        // When
+        wizard.redoLastSpell()
+        wizard.redoLastSpell()
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.SMALL, Visibility.INVISIBLE)
+    }
+
+    @Test
+    fun `should do nothing when undoing with no spells cast`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+
+        // When
+        wizard.undoLastSpell()
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.NORMAL, Visibility.VISIBLE)
+    }
+
+    @Test
+    fun `should do nothing when redoing with no spells undone`() {
+        // Given
+        val wizard = Wizard()
+        val goblin = Goblin()
+
+        // When
+        wizard.redoLastSpell()
+
+        // Then
+        verifyGoblin(goblin, "Goblin", Size.NORMAL, Visibility.VISIBLE)
+    }
+
+    private fun verifyGoblin(
+        goblin: Goblin,
+        expectedName: String,
+        expectedSize: Size,
+        expectedVisibility: Visibility,
+    ) {
+        assertEquals(expectedName, goblin.toString())
+        assertEquals(expectedSize, goblin.size)
+        assertEquals(expectedVisibility, goblin.visibility)
+    }
+}


### PR DESCRIPTION
Add Command design pattern implementation

Closes #407

- Ports the Command pattern from the Java reference repo to idiomatic Kotlin
- Uses `fun interface`-style approach with lambda undo/redo stacks via `ArrayDeque`
- Implements `Target` (receiver), `Wizard` (invoker) with undo/redo, `Goblin` (concrete target)
- Enums `Size` and `Visibility` with alphabetical entries and `toString()` override
- Full test coverage including undo, redo, and edge cases
- README with Mermaid class and sequence diagrams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Command pattern demo with full undo/redo behavior and a runnable example showcasing state changes.

* **Documentation**
  * Added a comprehensive Command pattern guide with intent, real-world example, sequence and class diagrams, applicability, consequences, and references.

* **Tests**
  * Added tests covering command execution, undo/redo flows, and edge cases to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->