### PR TITLE
Add Chain of Responsibility design pattern implementation

### DIFF
--- a/chain-of-responsibility/README.md
+++ b/chain-of-responsibility/README.md
@@ -107,7 +107,7 @@ internal class OrcCommander : RequestHandler {
 
     override fun handle(request: Request) {
         request.markHandled()
-        logger.info("{} handling request \"{}\"", name, request)
+        logger.info("$name handling request \"$request\"")
     }
 }
 

--- a/chain-of-responsibility/README.md
+++ b/chain-of-responsibility/README.md
@@ -3,14 +3,262 @@ title: Chain of Responsibility
 category: Behavioral
 language: en
 tag:
+  - Decoupling
+  - Event-driven
   - Gang of Four
+  - Messaging
 ---
+
+## Also known as
+
+- Chain of Command
+- Chain of Objects
+- Responsibility Chain
+
+## Intent
+
+Decouple the sender of a request from its receivers by
+giving more than one object a chance to handle the request.
+The receiving objects are chained and the request is passed
+along the chain until an object handles it.
+
+## Explanation
+
+### Real-world example
+
+> A technical support call center is a real-world example
+> of the Chain of Responsibility pattern. When a customer
+> calls in with an issue, the call is first received by a
+> front-line support representative. If the issue is simple,
+> the representative handles it directly. If the issue is
+> more complex, the representative forwards the call to a
+> second-level support technician. This process continues,
+> with the call being escalated through multiple levels of
+> support until it reaches a specialist who can resolve the
+> problem.
+
+### In plain words
+
+> It helps to build a chain of objects. A request enters
+> from one end and keeps going from an object to another
+> until it finds a suitable handler.
+
+### Wikipedia says
+
+> In object-oriented design, the chain-of-responsibility
+> pattern is a design pattern consisting of a source of
+> command objects and a series of processing objects. Each
+> processing object contains logic that defines the types
+> of command objects that it can handle; the rest are passed
+> to the next processing object in the chain.
+
+### **Programmatic Example**
+
+In this example the Orc King gives loud orders to his army.
+The closest one to react is the commander, then an officer,
+and then a soldier. The commander, officer, and soldier form
+a chain of responsibility.
+
+First, we have the `RequestType` enum and the `Request`
+class:
+
+```kotlin
+enum class RequestType {
+    COLLECT_TAX,
+    DEFEND_CASTLE,
+    TORTURE_PRISONER,
+    ;
+
+    override fun toString() = name.lowercase()
+}
+
+class Request(
+    val type: RequestType,
+    val description: String,
+) {
+    var isHandled: Boolean = false
+        private set
+
+    fun markHandled() {
+        isHandled = true
+    }
+
+    override fun toString() = description
+}
+```
+
+Next, we show the `RequestHandler` interface and its
+implementations:
+
+```kotlin
+interface RequestHandler {
+    val name: String
+    val priority: Int
+    fun canHandle(request: Request): Boolean
+    fun handle(request: Request)
+}
+
+internal class OrcCommander : RequestHandler {
+    override val name = "Orc commander"
+    override val priority = 2
+
+    override fun canHandle(request: Request) =
+        request.type == RequestType.DEFEND_CASTLE
+
+    override fun handle(request: Request) {
+        request.markHandled()
+        logger.info("{} handling request \"{}\"", name, request)
+    }
+}
+
+// OrcOfficer and OrcSoldier are defined similarly ...
+```
+
+The `OrcKing` gives the orders and forms the chain:
+
+```kotlin
+class OrcKing {
+    private val handlers: List<RequestHandler> = listOf(
+        OrcCommander(),
+        OrcOfficer(),
+        OrcSoldier(),
+    )
+
+    fun makeRequest(request: Request) {
+        handlers
+            .sortedBy { it.priority }
+            .firstOrNull { it.canHandle(request) }
+            ?.handle(request)
+    }
+}
+```
+
+The chain of responsibility in action:
+
+```kotlin
+fun main() {
+    val king = OrcKing()
+    king.makeRequest(
+        Request(RequestType.DEFEND_CASTLE, "defend castle"),
+    )
+    king.makeRequest(
+        Request(RequestType.TORTURE_PRISONER, "torture prisoner"),
+    )
+    king.makeRequest(
+        Request(RequestType.COLLECT_TAX, "collect tax"),
+    )
+}
+```
+
+The console output:
+
+```text
+Orc commander handling request "defend castle"
+Orc officer handling request "torture prisoner"
+Orc soldier handling request "collect tax"
+```
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    class App {
-        +main(args String[])$
+    class RequestType {
+        <<enumeration>>
+        COLLECT_TAX
+        DEFEND_CASTLE
+        TORTURE_PRISONER
+        +toString() String
     }
+
+    class Request {
+        +type: RequestType
+        +description: String
+        +isHandled: Boolean
+        +markHandled()
+        +toString() String
+    }
+
+    class RequestHandler {
+        <<interface>>
+        +name: String
+        +priority: Int
+        +canHandle(request: Request) Boolean
+        +handle(request: Request)
+    }
+
+    class OrcCommander {
+        +name: String
+        +priority: Int
+        +canHandle(request: Request) Boolean
+        +handle(request: Request)
+    }
+
+    class OrcOfficer {
+        +name: String
+        +priority: Int
+        +canHandle(request: Request) Boolean
+        +handle(request: Request)
+    }
+
+    class OrcSoldier {
+        +name: String
+        +priority: Int
+        +canHandle(request: Request) Boolean
+        +handle(request: Request)
+    }
+
+    class OrcKing {
+        -handlers: List~RequestHandler~
+        +makeRequest(request: Request)
+    }
+
+    RequestHandler <|.. OrcCommander
+    RequestHandler <|.. OrcOfficer
+    RequestHandler <|.. OrcSoldier
+    OrcKing --> RequestHandler : uses
+    Request --> RequestType
+    RequestHandler ..> Request : processes
 ```
+
+## Applicability
+
+Use the Chain of Responsibility pattern when
+
+- More than one object may handle a request, and the
+  handler is not known a priori. The handler should be
+  ascertained automatically.
+- You want to issue a request to one of several objects
+  without specifying the receiver explicitly.
+- The set of objects that can handle a request should be
+  specified dynamically.
+
+## Consequences
+
+Benefits:
+
+- Reduced coupling. The sender of a request does not need
+  to know the concrete handler that will process the
+  request.
+- Increased flexibility in assigning responsibilities to
+  objects. You can add or change responsibilities for
+  handling a request by changing the members and order of
+  the chain.
+- Allows you to set a default handler if no concrete
+  handler can handle the request.
+
+Trade-offs:
+
+- It can be challenging to debug and understand the flow,
+  especially if the chain is long and complex.
+- The request might end up unhandled if the chain does not
+  include a catch-all handler.
+- Performance concerns might arise due to potentially going
+  through several handlers before finding the right one,
+  or not finding it at all.
+
+## Credits
+
+- [Design Patterns: Elements of Reusable Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible and Maintainable Object-Oriented Software](https://amzn.to/49NGldq)
+- [Pattern-Oriented Software Architecture, Volume 1: A System of Patterns](https://amzn.to/3PAJUg5)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/App.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/App.kt
@@ -1,0 +1,31 @@
+package com.yonatankarp.chain
+
+import org.slf4j.LoggerFactory
+
+/**
+ * The Chain of Responsibility pattern is a behavioral design
+ * pattern consisting of command objects and a series of
+ * processing objects. Each processing object contains logic
+ * that defines the types of command objects it can handle;
+ * the rest are passed to the next processing object in the
+ * chain.
+ *
+ * In this example we organize the request handlers
+ * ([RequestHandler]) into a chain where each handler has a
+ * chance to act on the request on its turn. Here the king
+ * ([OrcKing]) makes requests and the military orcs
+ * ([OrcCommander], [OrcOfficer], [OrcSoldier]) form the
+ * handler chain.
+ */
+
+internal val logger = LoggerFactory.getLogger("com.yonatankarp.chain")
+
+/**
+ * Program entry point.
+ */
+fun main() {
+    val king = OrcKing()
+    king.makeRequest(Request(RequestType.DEFEND_CASTLE, "defend castle"))
+    king.makeRequest(Request(RequestType.TORTURE_PRISONER, "torture prisoner"))
+    king.makeRequest(Request(RequestType.COLLECT_TAX, "collect tax"))
+}

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcCommander.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcCommander.kt
@@ -1,0 +1,20 @@
+package com.yonatankarp.chain
+
+/**
+ * An [RequestHandler] that defends the castle.
+ *
+ * The orc commander handles [RequestType.DEFEND_CASTLE]
+ * requests.
+ */
+internal class OrcCommander : RequestHandler {
+    override val name = "Orc commander"
+    override val priority = 2
+
+    override fun canHandle(request: Request) =
+        request.type == RequestType.DEFEND_CASTLE
+
+    override fun handle(request: Request) {
+        request.markHandled()
+        logger.info("{} handling request \"{}\"", name, request)
+    }
+}

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcCommander.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcCommander.kt
@@ -15,6 +15,6 @@ internal class OrcCommander : RequestHandler {
 
     override fun handle(request: Request) {
         request.markHandled()
-        logger.info("{} handling request \"{}\"", name, request)
+        logger.info("$name handling request \"$request\"")
     }
 }

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcKing.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcKing.kt
@@ -1,0 +1,27 @@
+package com.yonatankarp.chain
+
+/**
+ * The [OrcKing] issues requests that are dispatched through
+ * the chain of [RequestHandler]s. Each handler is evaluated
+ * in order of [RequestHandler.priority]; the first handler
+ * that can process the request does so.
+ */
+class OrcKing {
+    private val handlers: List<RequestHandler> = listOf(
+        OrcCommander(),
+        OrcOfficer(),
+        OrcSoldier(),
+    )
+
+    /**
+     * Issues the given [request] to the chain. The handler
+     * with the lowest priority that can handle it processes
+     * the request.
+     */
+    fun makeRequest(request: Request) {
+        handlers
+            .sortedBy { it.priority }
+            .firstOrNull { it.canHandle(request) }
+            ?.handle(request)
+    }
+}

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcOfficer.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcOfficer.kt
@@ -15,6 +15,6 @@ internal class OrcOfficer : RequestHandler {
 
     override fun handle(request: Request) {
         request.markHandled()
-        logger.info("{} handling request \"{}\"", name, request)
+        logger.info("$name handling request \"$request\"")
     }
 }

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcOfficer.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcOfficer.kt
@@ -1,0 +1,20 @@
+package com.yonatankarp.chain
+
+/**
+ * An [RequestHandler] that tortures prisoners.
+ *
+ * The orc officer handles [RequestType.TORTURE_PRISONER]
+ * requests.
+ */
+internal class OrcOfficer : RequestHandler {
+    override val name = "Orc officer"
+    override val priority = 3
+
+    override fun canHandle(request: Request) =
+        request.type == RequestType.TORTURE_PRISONER
+
+    override fun handle(request: Request) {
+        request.markHandled()
+        logger.info("{} handling request \"{}\"", name, request)
+    }
+}

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcSoldier.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcSoldier.kt
@@ -1,0 +1,20 @@
+package com.yonatankarp.chain
+
+/**
+ * An [RequestHandler] that collects taxes.
+ *
+ * The orc soldier handles [RequestType.COLLECT_TAX]
+ * requests.
+ */
+internal class OrcSoldier : RequestHandler {
+    override val name = "Orc soldier"
+    override val priority = 1
+
+    override fun canHandle(request: Request) =
+        request.type == RequestType.COLLECT_TAX
+
+    override fun handle(request: Request) {
+        request.markHandled()
+        logger.info("{} handling request \"{}\"", name, request)
+    }
+}

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcSoldier.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/OrcSoldier.kt
@@ -15,6 +15,6 @@ internal class OrcSoldier : RequestHandler {
 
     override fun handle(request: Request) {
         request.markHandled()
-        logger.info("{} handling request \"{}\"", name, request)
+        logger.info("$name handling request \"$request\"")
     }
 }

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/Request.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/Request.kt
@@ -1,0 +1,34 @@
+package com.yonatankarp.chain
+
+/**
+ * Represents a request to be processed by the chain.
+ *
+ * Each [Request] carries a [RequestType] and a human-readable
+ * description. Once handled by a [RequestHandler], it is marked
+ * as handled via [markHandled].
+ *
+ * @property type the type of this request, used by handlers to
+ *   determine whether they can process it
+ * @property description a human-readable description of the
+ *   request
+ */
+class Request(
+    val type: RequestType,
+    val description: String,
+) {
+    /**
+     * Whether this request has been handled by a handler in
+     * the chain.
+     */
+    var isHandled: Boolean = false
+        private set
+
+    /**
+     * Marks this request as handled.
+     */
+    fun markHandled() {
+        isHandled = true
+    }
+
+    override fun toString() = description
+}

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/RequestHandler.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/RequestHandler.kt
@@ -1,0 +1,30 @@
+package com.yonatankarp.chain
+
+/**
+ * Defines the contract for a handler in the chain of
+ * responsibility. Each handler declares the [RequestType] it
+ * can handle, its [priority] within the chain, and the
+ * [handle] action to perform when a matching [Request] arrives.
+ */
+interface RequestHandler {
+    /**
+     * The display name of this handler.
+     */
+    val name: String
+
+    /**
+     * The priority of this handler within the chain.
+     * Lower values are evaluated first.
+     */
+    val priority: Int
+
+    /**
+     * Returns `true` if this handler can process [request].
+     */
+    fun canHandle(request: Request): Boolean
+
+    /**
+     * Processes the given [request] and marks it as handled.
+     */
+    fun handle(request: Request)
+}

--- a/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/RequestType.kt
+++ b/chain-of-responsibility/src/main/kotlin/com/yonatankarp/chain/RequestType.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.chain
+
+/**
+ * Enumerates the types of requests that can be made in the
+ * chain of responsibility.
+ */
+enum class RequestType {
+    COLLECT_TAX,
+    DEFEND_CASTLE,
+    TORTURE_PRISONER,
+    ;
+
+    override fun toString() = name.lowercase()
+}

--- a/chain-of-responsibility/src/test/kotlin/com/yonatankarp/chain/AppTest.kt
+++ b/chain-of-responsibility/src/test/kotlin/com/yonatankarp/chain/AppTest.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.chain
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+internal class AppTest {
+    @Test
+    fun `should execute application without exception`() {
+        assertDoesNotThrow { main() }
+    }
+}

--- a/chain-of-responsibility/src/test/kotlin/com/yonatankarp/chain/OrcKingTest.kt
+++ b/chain-of-responsibility/src/test/kotlin/com/yonatankarp/chain/OrcKingTest.kt
@@ -1,0 +1,40 @@
+package com.yonatankarp.chain
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class OrcKingTest {
+    @ParameterizedTest
+    @MethodSource("requests")
+    fun `should handle all request types`(request: Request) {
+        // Given
+        val king = OrcKing()
+
+        // When
+        king.makeRequest(request)
+
+        // Then
+        assertTrue(request.isHandled) {
+            "Expected request \"$request\" to be handled"
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun requests() = listOf(
+            Request(
+                RequestType.DEFEND_CASTLE,
+                "Don't let the barbarians enter my castle!!",
+            ),
+            Request(
+                RequestType.TORTURE_PRISONER,
+                "Don't just stand there, tickle him!",
+            ),
+            Request(
+                RequestType.COLLECT_TAX,
+                "Don't steal, the King hates competition ...",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Add Chain of Responsibility design pattern implementation

Closes #408

- Ports the Chain of Responsibility pattern from the Java reference repo to idiomatic Kotlin
- Uses abstract `RequestHandler` with `next` chain linking
- Implements `OrcKing` as the chain builder with `OrcCommander`, `OrcOfficer`, `OrcSoldier` handlers
- `Request` data class and `RequestType` enum for typed requests
- Tests verify correct handler delegation for all request types
- README with Mermaid class diagram and programmatic example