### PR TITLE
Add Mediator design pattern implementation

### DIFF
--- a/mediator/README.md
+++ b/mediator/README.md
@@ -3,14 +3,279 @@ title: Mediator
 category: Behavioral
 language: en
 tag:
+  - Decoupling
   - Gang of Four
+  - Messaging
+  - Object composition
 ---
+
+## Also known as
+
+- Controller
+
+## Intent
+
+Reduce the complexity of communication between multiple objects
+by providing a centralized mediator class that handles the
+interactions between different classes, reducing their direct
+dependencies on each other.
+
+## Explanation
+
+Real-world example
+
+> Imagine an air traffic control system at a busy airport,
+> where the air traffic controller acts as a mediator. Instead
+> of each pilot communicating directly with every other pilot,
+> all communication goes through the air traffic controller.
+> The controller receives requests, processes them, and gives
+> clear, organized instructions to each pilot.
+
+In plain words
+
+> Mediator decouples a set of classes by forcing their
+> communications to flow through a mediating object.
+
+Wikipedia says
+
+> In software engineering, the mediator pattern defines an
+> object that encapsulates how a set of objects interact.
+> This pattern is considered to be a behavioral pattern due
+> to the way it can alter the program's running behavior.
+> With the mediator pattern, communication between objects is
+> encapsulated within a mediator object. Objects no longer
+> communicate directly with each other, but instead
+> communicate through the mediator. This reduces the
+> dependencies between communicating objects, thereby
+> reducing coupling.
+
+Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant H as Hobbit
+    participant P as AdventuringParty
+    participant W as Wizard
+    participant R as Rogue
+
+    H->>P: act(ENEMY)
+    P->>W: partyAction(ENEMY)
+    P->>R: partyAction(ENEMY)
+```
+
+**Programmatic Example**
+
+The party members `Rogue`, `Wizard`, `Hobbit`, and `Hunter`
+all inherit from the sealed `PartyMemberBase` class which
+implements the `PartyMember` interface.
+
+```kotlin
+interface PartyMember {
+    fun joinedParty(party: Party)
+    fun partyAction(action: Action)
+    fun act(action: Action)
+}
+
+sealed class PartyMemberBase : PartyMember {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private var party: Party? = null
+
+    override fun joinedParty(party: Party) {
+        logger.info("$this joins the party")
+        this.party = party
+    }
+
+    override fun partyAction(action: Action) {
+        logger.info("$this ${action.description}")
+    }
+
+    override fun act(action: Action) {
+        party?.let {
+            logger.info("$this $action")
+            it.act(this, action)
+        }
+    }
+
+    abstract override fun toString(): String
+}
+
+internal class Hobbit : PartyMemberBase() {
+    override fun toString(): String = "Hobbit"
+}
+
+// Hunter, Rogue, and Wizard are implemented similarly
+```
+
+The mediator system consists of the `Party` interface and its
+`AdventuringParty` implementation.
+
+```kotlin
+interface Party {
+    fun addMember(member: PartyMember)
+    fun act(actor: PartyMember, action: Action)
+}
+
+internal class AdventuringParty : Party {
+    private val members = mutableListOf<PartyMember>()
+
+    override fun addMember(member: PartyMember) {
+        members.add(member)
+        member.joinedParty(this)
+    }
+
+    override fun act(actor: PartyMember, action: Action) {
+        members
+            .filter { it != actor }
+            .forEach { it.partyAction(action) }
+    }
+}
+```
+
+Here is a demo showing the mediator pattern in action.
+
+```kotlin
+fun main() {
+    val party: Party = AdventuringParty()
+    val hobbit = Hobbit()
+    val wizard = Wizard()
+    val rogue = Rogue()
+    val hunter = Hunter()
+
+    party.addMember(hobbit)
+    party.addMember(wizard)
+    party.addMember(rogue)
+    party.addMember(hunter)
+
+    hobbit.act(Action.ENEMY)
+    wizard.act(Action.TALE)
+    rogue.act(Action.GOLD)
+    hunter.act(Action.HUNT)
+}
+```
+
+Program output:
+
+```text
+Hobbit joins the party
+Wizard joins the party
+Rogue joins the party
+Hunter joins the party
+Hobbit spotted enemies
+Wizard runs for cover
+Rogue runs for cover
+Hunter runs for cover
+Wizard tells a tale
+Hobbit comes to listen
+Rogue comes to listen
+Hunter comes to listen
+Rogue found gold
+Hobbit takes his share of the gold
+Wizard takes his share of the gold
+Hunter takes his share of the gold
+Hunter hunted a rabbit
+Hobbit arrives for dinner
+Wizard arrives for dinner
+Rogue arrives for dinner
+```
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    class App {
-        +main(args String[])$
+    class Party {
+        <<interface>>
+        +addMember(member: PartyMember)
+        +act(actor: PartyMember, action: Action)
     }
+
+    class AdventuringParty {
+        -members: MutableList~PartyMember~
+        +addMember(member: PartyMember)
+        +act(actor: PartyMember, action: Action)
+    }
+
+    class PartyMember {
+        <<interface>>
+        +joinedParty(party: Party)
+        +partyAction(action: Action)
+        +act(action: Action)
+    }
+
+    class PartyMemberBase {
+        <<sealed>>
+        -party: Party?
+        +joinedParty(party: Party)
+        +partyAction(action: Action)
+        +act(action: Action)
+        +toString(): String*
+    }
+
+    class Hobbit {
+        +toString(): String
+    }
+
+    class Hunter {
+        +toString(): String
+    }
+
+    class Rogue {
+        +toString(): String
+    }
+
+    class Wizard {
+        +toString(): String
+    }
+
+    class Action {
+        <<enumeration>>
+        ENEMY
+        GOLD
+        HUNT
+        NONE
+        TALE
+        +description: String
+        +toString(): String
+    }
+
+    Party <|.. AdventuringParty
+    PartyMember <|.. PartyMemberBase
+    PartyMemberBase <|-- Hobbit
+    PartyMemberBase <|-- Hunter
+    PartyMemberBase <|-- Rogue
+    PartyMemberBase <|-- Wizard
+    AdventuringParty --> PartyMember
+    PartyMemberBase --> Party
+    PartyMemberBase --> Action
 ```
+
+## Applicability
+
+Use the Mediator pattern when:
+
+- A set of objects communicate in well-defined but complex
+  ways and the resulting interdependencies are unstructured
+  and difficult to understand
+- Reusing an object is difficult because it refers to and
+  communicates with many other objects
+- A behavior that is distributed between several classes
+  should be customizable without a lot of subclassing
+
+## Consequences
+
+Benefits:
+
+- Reduces coupling between components of a program, fostering
+  better organization and easier maintenance
+- Centralizes control: the mediator pattern centralizes the
+  control logic, making it easier to comprehend and manage
+
+Trade-offs:
+
+- The mediator can become a god object coupled with all
+  classes in the system, gaining too much responsibility and
+  complexity
+
+## Credits
+
+- [Design Patterns: Elements of Reusable Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible and Maintainable Object-Oriented Software](https://amzn.to/49NGldq)

--- a/mediator/README.md
+++ b/mediator/README.md
@@ -63,7 +63,7 @@ sequenceDiagram
     P->>R: partyAction(ENEMY)
 ```
 
-**Programmatic Example**
+### **Programmatic Example**
 
 The party members `Rogue`, `Wizard`, `Hobbit`, and `Hunter`
 all inherit from the sealed `PartyMemberBase` class which

--- a/mediator/build.gradle.kts
+++ b/mediator/build.gradle.kts
@@ -2,9 +2,20 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply true
 }
 
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/yonatankarp/kotlin-junit-tools")
+        credentials {
+            username = project.findProperty("gpr.user")?.toString() ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key")?.toString() ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
 dependencies {
     implementation(libs.bundles.kotlin.all)
     implementation(libs.bundles.log.all)
+    testImplementation(libs.kotlin.junit.tools)
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.tests.all)
 }

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/Action.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/Action.kt
@@ -1,0 +1,21 @@
+package com.yonatankarp.mediator
+
+/**
+ * Enumerates the actions that a [PartyMember] can perform.
+ *
+ * Each action has a [title] shown when the member acts and a
+ * [description] shown when other members react.
+ */
+enum class Action(
+    private val title: String,
+    val description: String,
+) {
+    ENEMY("spotted enemies", "runs for cover"),
+    GOLD("found gold", "takes his share of the gold"),
+    HUNT("hunted a rabbit", "arrives for dinner"),
+    NONE("", ""),
+    TALE("tells a tale", "comes to listen"),
+    ;
+
+    override fun toString(): String = title
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/AdventuringParty.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/AdventuringParty.kt
@@ -1,0 +1,20 @@
+package com.yonatankarp.mediator
+
+/**
+ * Concrete [Party] mediator that keeps track of its members and
+ * relays actions to every member except the one who performed it.
+ */
+internal class AdventuringParty : Party {
+    private val members = mutableListOf<PartyMember>()
+
+    override fun addMember(member: PartyMember) {
+        members.add(member)
+        member.joinedParty(this)
+    }
+
+    override fun act(actor: PartyMember, action: Action) {
+        members
+            .filter { it != actor }
+            .forEach { it.partyAction(action) }
+    }
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/App.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/App.kt
@@ -1,0 +1,42 @@
+package com.yonatankarp.mediator
+
+/**
+ * The Mediator pattern defines an object that encapsulates how a set
+ * of objects interact. This pattern is considered to be a behavioral
+ * pattern due to the way it can alter the program's running behavior.
+ *
+ * With the Mediator pattern, communication between objects is
+ * encapsulated within a mediator object. Objects no longer communicate
+ * directly with each other, but instead communicate through the
+ * mediator. This reduces the dependencies between communicating
+ * objects, thereby lowering the coupling.
+ *
+ * In this example the mediator encapsulates how a set of objects
+ * ([PartyMember]) interact. Instead of referring to each other
+ * directly they use the mediator ([Party]) interface.
+ */
+
+/**
+ * Program entry point.
+ */
+fun main() {
+    // create party and members
+    val party: Party = AdventuringParty()
+    val hobbit = Hobbit()
+    val wizard = Wizard()
+    val rogue = Rogue()
+    val hunter = Hunter()
+
+    // add party members
+    party.addMember(hobbit)
+    party.addMember(wizard)
+    party.addMember(rogue)
+    party.addMember(hunter)
+
+    // perform actions -> the other party members
+    // are notified by the party
+    hobbit.act(Action.ENEMY)
+    wizard.act(Action.TALE)
+    rogue.act(Action.GOLD)
+    hunter.act(Action.HUNT)
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/Hobbit.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/Hobbit.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.mediator
+
+/**
+ * Hobbit party member.
+ */
+internal class Hobbit : PartyMemberBase() {
+    override fun toString(): String = "Hobbit"
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/Hunter.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/Hunter.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.mediator
+
+/**
+ * Hunter party member.
+ */
+internal class Hunter : PartyMemberBase() {
+    override fun toString(): String = "Hunter"
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/Party.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/Party.kt
@@ -1,0 +1,21 @@
+package com.yonatankarp.mediator
+
+/**
+ * The mediator interface that coordinates interactions between
+ * [PartyMember] instances.
+ *
+ * When a member performs an action the party notifies every other
+ * member, decoupling the members from one another.
+ */
+interface Party {
+    /**
+     * Adds a [member] to this party.
+     */
+    fun addMember(member: PartyMember)
+
+    /**
+     * Broadcasts the [action] performed by [actor] to every other
+     * party member.
+     */
+    fun act(actor: PartyMember, action: Action)
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/PartyMember.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/PartyMember.kt
@@ -1,0 +1,23 @@
+package com.yonatankarp.mediator
+
+/**
+ * Interface for party members that interact through a [Party]
+ * mediator.
+ */
+interface PartyMember {
+    /**
+     * Called when this member joins the given [party].
+     */
+    fun joinedParty(party: Party)
+
+    /**
+     * Called by the [Party] to notify this member of another
+     * member's [action].
+     */
+    fun partyAction(action: Action)
+
+    /**
+     * Performs the given [action] and notifies the party.
+     */
+    fun act(action: Action)
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/PartyMemberBase.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/PartyMemberBase.kt
@@ -1,0 +1,33 @@
+package com.yonatankarp.mediator
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Abstract base class for [PartyMember] implementations.
+ *
+ * Subclasses only need to provide a human-readable [toString]
+ * representation; all mediator interaction logic is handled here.
+ */
+sealed class PartyMemberBase : PartyMember {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private var party: Party? = null
+
+    override fun joinedParty(party: Party) {
+        logger.info("$this joins the party")
+        this.party = party
+    }
+
+    override fun partyAction(action: Action) {
+        logger.info("$this ${action.description}")
+    }
+
+    override fun act(action: Action) {
+        party?.let {
+            logger.info("$this $action")
+            it.act(this, action)
+        }
+    }
+
+    abstract override fun toString(): String
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/Rogue.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/Rogue.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.mediator
+
+/**
+ * Rogue party member.
+ */
+internal class Rogue : PartyMemberBase() {
+    override fun toString(): String = "Rogue"
+}

--- a/mediator/src/main/kotlin/com/yonatankarp/mediator/Wizard.kt
+++ b/mediator/src/main/kotlin/com/yonatankarp/mediator/Wizard.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.mediator
+
+/**
+ * Wizard party member.
+ */
+internal class Wizard : PartyMemberBase() {
+    override fun toString(): String = "Wizard"
+}

--- a/mediator/src/test/kotlin/com/yonatankarp/mediator/AdventuringPartyTest.kt
+++ b/mediator/src/test/kotlin/com/yonatankarp/mediator/AdventuringPartyTest.kt
@@ -1,0 +1,34 @@
+package com.yonatankarp.mediator
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that [AdventuringParty] correctly relays actions
+ * between members through the mediator.
+ */
+internal class AdventuringPartyTest {
+    @Test
+    fun `should notify other members but not the actor`() {
+        // Given
+        val member1 = mockk<PartyMember>(relaxed = true)
+        val member2 = mockk<PartyMember>(relaxed = true)
+        val party = AdventuringParty()
+
+        // When
+        party.addMember(member1)
+        party.addMember(member2)
+
+        // Then
+        verify { member1.joinedParty(party) }
+        verify { member2.joinedParty(party) }
+
+        // When
+        party.act(member1, Action.GOLD)
+
+        // Then
+        verify(exactly = 0) { member1.partyAction(any()) }
+        verify { member2.partyAction(Action.GOLD) }
+    }
+}

--- a/mediator/src/test/kotlin/com/yonatankarp/mediator/AppTest.kt
+++ b/mediator/src/test/kotlin/com/yonatankarp/mediator/AppTest.kt
@@ -1,0 +1,13 @@
+package com.yonatankarp.mediator
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that the application entry point runs without errors.
+ */
+internal class AppTest {
+    @Test
+    fun `should execute application without exception`() =
+        assertDoesNotThrow { main() }
+}

--- a/mediator/src/test/kotlin/com/yonatankarp/mediator/PartyMemberTest.kt
+++ b/mediator/src/test/kotlin/com/yonatankarp/mediator/PartyMemberTest.kt
@@ -1,0 +1,75 @@
+package com.yonatankarp.mediator
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * Verifies logging and mediator interaction for all
+ * [PartyMemberBase] subclasses.
+ */
+internal class PartyMemberTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @ParameterizedTest
+    @MethodSource("memberProvider")
+    fun `should log reaction for each party action`(
+        member: PartyMember,
+    ) {
+        Action.entries.forEach { action ->
+            member.partyAction(action)
+            assertTrue(
+                appender.logContains("$member ${action.description}"),
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("memberProvider")
+    fun `should delegate action to party when joined`(
+        member: PartyMember,
+    ) {
+        // Given
+        val party = mockk<Party>(relaxed = true)
+
+        // When — join a party
+        member.joinedParty(party)
+
+        // Then
+        assertTrue(appender.logContains("$member joins the party"))
+
+        // When — act after joining
+        member.act(Action.GOLD)
+
+        // Then
+        assertTrue(appender.logContains("$member ${Action.GOLD}"))
+        verify { party.act(member, Action.GOLD) }
+    }
+
+    @ParameterizedTest
+    @MethodSource("memberProvider")
+    fun `should have class name as toString`(member: PartyMember) =
+        assertTrue(member.toString() == member.javaClass.simpleName)
+
+    companion object {
+        @JvmStatic
+        fun memberProvider(): List<PartyMember> =
+            listOf(Hobbit(), Hunter(), Rogue(), Wizard())
+    }
+}


### PR DESCRIPTION
Add Mediator design pattern implementation

Closes #409

- Ports the Mediator pattern from the Java reference repo to idiomatic Kotlin
- `Party` interface as mediator, `AdventuringParty` as concrete mediator
- `PartyMemberBase` sealed class with `Hobbit`, `Hunter`, `Rogue`, `Wizard` members
- Uses Kotlin string templates for logging (not SLF4J placeholders)
- Tests with MockK for mediator delegation and InMemoryLoggerAppender for log verification
- README with Mermaid class and sequence diagrams