### PR TITLE
Add Visitor design pattern implementation

### DIFF
--- a/visitor/README.md
+++ b/visitor/README.md
@@ -3,14 +3,299 @@ title: Visitor
 category: Behavioral
 language: en
 tag:
+  - Decoupling
+  - Extensibility
   - Gang of Four
+  - Object composition
+  - Polymorphism
 ---
+
+## Intent
+
+Represent an operation to be performed on the elements
+of an object structure. Visitor lets you define a new
+operation without changing the classes of the elements
+on which it operates.
+
+## Explanation
+
+### Real-world example
+
+> Imagine a museum where visitors can take guided tours
+> to learn about different types of exhibits such as
+> paintings, sculptures, and historical artifacts. Each
+> exhibit type requires a different explanation, which
+> is provided by specialized tour guides.
+>
+> The exhibits are like the elements in the Visitor
+> pattern, and the tour guides are like the visitors.
+> New guides with new types of tours can be added
+> without modifying the exhibits themselves. Each guide
+> implements a specific way to interact with the
+> exhibits, separating the operations from the objects
+> they operate on.
+
+### In plain words
+
+> The Visitor pattern defines operations that can be
+> performed on nodes of a data structure without
+> changing the node classes.
+
+### Wikipedia says
+
+> In object-oriented programming and software
+> engineering, the visitor design pattern is a way of
+> separating an algorithm from an object structure on
+> which it operates. A practical result of this
+> separation is the ability to add new operations to
+> existing object structures without modifying the
+> structures.
+
+### Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Commander
+    participant Sergeant
+    participant Soldier
+    participant SoldierVisitor
+
+    Client ->> Commander: accept(SoldierVisitor)
+    Commander ->> SoldierVisitor: visit(this)
+    Commander ->> Sergeant: accept(SoldierVisitor)
+    Sergeant ->> SoldierVisitor: visit(this)
+    Sergeant ->> Soldier: accept(SoldierVisitor)
+    Soldier ->> SoldierVisitor: visit(this)
+    SoldierVisitor -->> Soldier: "Greetings soldier"
+```
+
+### **Programmatic Example**
+
+Consider a tree structure with army units. A commander
+has two sergeants under it, and each sergeant has three
+soldiers under them. Given that the hierarchy
+implements the visitor pattern, we can easily create
+new objects that interact with the commander, sergeants,
+soldiers, or all of them.
+
+First, we have the `Unit` sealed class hierarchy and
+the `UnitVisitor` interface.
+
+```kotlin
+sealed class Unit(
+    val children: List<Unit> = emptyList(),
+) {
+    open fun accept(visitor: UnitVisitor) {
+        children.forEach { it.accept(visitor) }
+    }
+}
+
+interface UnitVisitor {
+    fun visit(soldier: Soldier)
+    fun visit(sergeant: Sergeant)
+    fun visit(commander: Commander)
+}
+```
+
+Then we have the concrete units `Commander`, `Sergeant`,
+and `Soldier`.
+
+```kotlin
+internal class Commander(
+    children: List<Unit> = emptyList(),
+) : Unit(children) {
+    override fun accept(visitor: UnitVisitor) {
+        visitor.visit(this)
+        super.accept(visitor)
+    }
+
+    override fun toString() = "commander"
+}
+
+internal class Sergeant(
+    children: List<Unit> = emptyList(),
+) : Unit(children) {
+    override fun accept(visitor: UnitVisitor) {
+        visitor.visit(this)
+        super.accept(visitor)
+    }
+
+    override fun toString() = "sergeant"
+}
+
+internal class Soldier(
+    children: List<Unit> = emptyList(),
+) : Unit(children) {
+    override fun accept(visitor: UnitVisitor) {
+        visitor.visit(this)
+        super.accept(visitor)
+    }
+
+    override fun toString() = "soldier"
+}
+```
+
+Here are the concrete visitors `CommanderVisitor`,
+`SergeantVisitor`, and `SoldierVisitor`.
+
+```kotlin
+internal class CommanderVisitor : UnitVisitor {
+    override fun visit(soldier: Soldier) {}
+    override fun visit(sergeant: Sergeant) {}
+    override fun visit(commander: Commander) {
+        logger.info("Good to see you {}", commander)
+    }
+}
+
+internal class SergeantVisitor : UnitVisitor {
+    override fun visit(soldier: Soldier) {}
+    override fun visit(sergeant: Sergeant) {
+        logger.info("Hello {}", sergeant)
+    }
+    override fun visit(commander: Commander) {}
+}
+
+internal class SoldierVisitor : UnitVisitor {
+    override fun visit(soldier: Soldier) {
+        logger.info("Greetings {}", soldier)
+    }
+    override fun visit(sergeant: Sergeant) {}
+    override fun visit(commander: Commander) {}
+}
+```
+
+Finally, we can show the power of visitors in action.
+
+```kotlin
+val commander = Commander(
+    listOf(
+        Sergeant(listOf(Soldier(), Soldier(), Soldier())),
+        Sergeant(listOf(Soldier(), Soldier(), Soldier())),
+    ),
+)
+
+commander.accept(SoldierVisitor())
+commander.accept(SergeantVisitor())
+commander.accept(CommanderVisitor())
+```
+
+Program output:
+
+```text
+Greetings soldier
+Greetings soldier
+Greetings soldier
+Greetings soldier
+Greetings soldier
+Greetings soldier
+Hello sergeant
+Hello sergeant
+Good to see you commander
+```
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    class App {
-        +main(args String[])$
+    class Unit {
+        <<sealed>>
+        +children List~Unit~
+        +accept(visitor UnitVisitor)
     }
+    class Commander {
+        +accept(visitor UnitVisitor)
+        +toString() String
+    }
+    class Sergeant {
+        +accept(visitor UnitVisitor)
+        +toString() String
+    }
+    class Soldier {
+        +accept(visitor UnitVisitor)
+        +toString() String
+    }
+    class UnitVisitor {
+        <<interface>>
+        +visit(soldier Soldier)
+        +visit(sergeant Sergeant)
+        +visit(commander Commander)
+    }
+    class CommanderVisitor {
+        +visit(soldier Soldier)
+        +visit(sergeant Sergeant)
+        +visit(commander Commander)
+    }
+    class SergeantVisitor {
+        +visit(soldier Soldier)
+        +visit(sergeant Sergeant)
+        +visit(commander Commander)
+    }
+    class SoldierVisitor {
+        +visit(soldier Soldier)
+        +visit(sergeant Sergeant)
+        +visit(commander Commander)
+    }
+    Commander --|> Unit
+    Sergeant --|> Unit
+    Soldier --|> Unit
+    CommanderVisitor ..|> UnitVisitor
+    SergeantVisitor ..|> UnitVisitor
+    SoldierVisitor ..|> UnitVisitor
+    Unit --> UnitVisitor : accepts
 ```
+
+## Applicability
+
+Use the Visitor pattern when:
+
+- You need to perform operations across a group of
+  similar objects without modifying their classes.
+- The class structure is stable, but you need to
+  perform new operations on the structure without
+  changing it.
+- The set of classes is fixed and only the operations
+  need to be extended.
+
+## Consequences
+
+Benefits:
+
+- Adding a new operation is straightforward because
+  you can add a new visitor without changing existing
+  code.
+- Single Responsibility Principle: the Visitor pattern
+  allows you to move related behavior into one class.
+- Open/Closed Principle: elements stay closed to
+  modification while visitors are open to extension.
+
+Trade-offs:
+
+- Adding new element classes requires changing both
+  the visitor interface and all of its concrete
+  visitors.
+- In complex systems, this pattern can introduce
+  circular dependencies between visitor and element
+  classes.
+- Visitor pattern requires that element classes expose
+  enough details to allow the visitor to do its job,
+  potentially breaking encapsulation.
+
+## Related Patterns
+
+- [Composite](../composite/README.md): The Visitor
+  pattern is often used in conjunction with the
+  Composite pattern, where the visitor can perform
+  operations over a composite structure.
+- [Strategy](../strategy/README.md): Visitor can be
+  considered a way of making strategies work on
+  objects that they were not designed to operate on.
+
+## Credits
+
+- [Design Patterns: Elements of Reusable
+  Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible
+  and Maintainable Object-Oriented
+  Software](https://amzn.to/49NGldq)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/visitor/build.gradle.kts
+++ b/visitor/build.gradle.kts
@@ -2,9 +2,20 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply true
 }
 
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/yonatankarp/kotlin-junit-tools")
+        credentials {
+            username = project.findProperty("gpr.user")?.toString() ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key")?.toString() ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
 dependencies {
     implementation(libs.bundles.kotlin.all)
     implementation(libs.bundles.log.all)
+    testImplementation(libs.kotlin.junit.tools)
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.tests.all)
 }

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/App.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/App.kt
@@ -1,0 +1,28 @@
+package com.yonatankarp.visitor
+
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("com.yonatankarp.visitor")
+
+/**
+ * The Visitor pattern defines a mechanism to apply operations on
+ * nodes in a hierarchy. New operations can be added without
+ * altering the node interface.
+ *
+ * In this example there is a unit hierarchy beginning from
+ * [Commander]. This hierarchy is traversed by visitors.
+ * [SoldierVisitor] applies its operation on [Soldier]s,
+ * [SergeantVisitor] on [Sergeant]s and so on.
+ */
+fun main() {
+    val commander = Commander(
+        listOf(
+            Sergeant(listOf(Soldier(), Soldier(), Soldier())),
+            Sergeant(listOf(Soldier(), Soldier(), Soldier())),
+        ),
+    )
+
+    commander.accept(SoldierVisitor())
+    commander.accept(SergeantVisitor())
+    commander.accept(CommanderVisitor())
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/Commander.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/Commander.kt
@@ -1,0 +1,26 @@
+package com.yonatankarp.visitor
+
+/**
+ * Represents a commander in the army hierarchy.
+ *
+ * A [Commander] sits at the top of the chain and may have
+ * subordinate [Unit] nodes.
+ *
+ * @param children subordinate units under this commander
+ */
+internal class Commander(
+    children: List<Unit> = emptyList(),
+) : Unit(children) {
+    /**
+     * Accepts a [UnitVisitor], visiting this commander first
+     * before delegating to child units.
+     *
+     * @param visitor the [UnitVisitor] to accept
+     */
+    override fun accept(visitor: UnitVisitor) {
+        visitor.visit(this)
+        super.accept(visitor)
+    }
+
+    override fun toString() = "commander"
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/CommanderVisitor.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/CommanderVisitor.kt
@@ -1,0 +1,24 @@
+package com.yonatankarp.visitor
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A [UnitVisitor] that only interacts with [Commander] units.
+ *
+ * [Soldier] and [Sergeant] visits are no-ops.
+ */
+internal class CommanderVisitor : UnitVisitor {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun visit(soldier: Soldier) {
+        // Do nothing
+    }
+
+    override fun visit(sergeant: Sergeant) {
+        // Do nothing
+    }
+
+    override fun visit(commander: Commander) {
+        logger.info("Good to see you $commander")
+    }
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/Sergeant.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/Sergeant.kt
@@ -1,0 +1,26 @@
+package com.yonatankarp.visitor
+
+/**
+ * Represents a sergeant in the army hierarchy.
+ *
+ * A [Sergeant] reports to a [Commander] and may have
+ * subordinate [Unit] nodes such as [Soldier]s.
+ *
+ * @param children subordinate units under this sergeant
+ */
+internal class Sergeant(
+    children: List<Unit> = emptyList(),
+) : Unit(children) {
+    /**
+     * Accepts a [UnitVisitor], visiting this sergeant first
+     * before delegating to child units.
+     *
+     * @param visitor the [UnitVisitor] to accept
+     */
+    override fun accept(visitor: UnitVisitor) {
+        visitor.visit(this)
+        super.accept(visitor)
+    }
+
+    override fun toString() = "sergeant"
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/SergeantVisitor.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/SergeantVisitor.kt
@@ -1,0 +1,24 @@
+package com.yonatankarp.visitor
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A [UnitVisitor] that only interacts with [Sergeant] units.
+ *
+ * [Soldier] and [Commander] visits are no-ops.
+ */
+internal class SergeantVisitor : UnitVisitor {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun visit(soldier: Soldier) {
+        // Do nothing
+    }
+
+    override fun visit(sergeant: Sergeant) {
+        logger.info("Hello $sergeant")
+    }
+
+    override fun visit(commander: Commander) {
+        // Do nothing
+    }
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/Soldier.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/Soldier.kt
@@ -1,0 +1,25 @@
+package com.yonatankarp.visitor
+
+/**
+ * Represents a soldier in the army hierarchy.
+ *
+ * A [Soldier] is a leaf node with no subordinates.
+ *
+ * @param children subordinate units (typically empty for a soldier)
+ */
+internal class Soldier(
+    children: List<Unit> = emptyList(),
+) : Unit(children) {
+    /**
+     * Accepts a [UnitVisitor], visiting this soldier first
+     * before delegating to child units.
+     *
+     * @param visitor the [UnitVisitor] to accept
+     */
+    override fun accept(visitor: UnitVisitor) {
+        visitor.visit(this)
+        super.accept(visitor)
+    }
+
+    override fun toString() = "soldier"
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/SoldierVisitor.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/SoldierVisitor.kt
@@ -1,0 +1,24 @@
+package com.yonatankarp.visitor
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A [UnitVisitor] that only interacts with [Soldier] units.
+ *
+ * [Sergeant] and [Commander] visits are no-ops.
+ */
+internal class SoldierVisitor : UnitVisitor {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun visit(soldier: Soldier) {
+        logger.info("Greetings $soldier")
+    }
+
+    override fun visit(sergeant: Sergeant) {
+        // Do nothing
+    }
+
+    override fun visit(commander: Commander) {
+        // Do nothing
+    }
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/Unit.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/Unit.kt
@@ -1,0 +1,21 @@
+package com.yonatankarp.visitor
+
+/**
+ * Base class for nodes in the army hierarchy.
+ *
+ * Each [Unit] may have child units that are visited after the
+ * unit itself when a [UnitVisitor] is accepted.
+ *
+ * @property children the subordinate units of this node
+ */
+internal sealed class Unit(val children: List<Unit> = emptyList()) {
+    /**
+     * Accepts a [UnitVisitor] by first visiting this node and
+     * then delegating to all [children].
+     *
+     * @param visitor the [UnitVisitor] to accept
+     */
+    open fun accept(visitor: UnitVisitor) {
+        children.forEach { it.accept(visitor) }
+    }
+}

--- a/visitor/src/main/kotlin/com/yonatankarp/visitor/UnitVisitor.kt
+++ b/visitor/src/main/kotlin/com/yonatankarp/visitor/UnitVisitor.kt
@@ -1,0 +1,30 @@
+package com.yonatankarp.visitor
+
+/**
+ * Visitor interface for the army [Unit] hierarchy.
+ *
+ * Each concrete visitor implements an operation for every unit
+ * type in the hierarchy.
+ */
+internal interface UnitVisitor {
+    /**
+     * Visits a [Soldier] unit.
+     *
+     * @param soldier the soldier to visit
+     */
+    fun visit(soldier: Soldier)
+
+    /**
+     * Visits a [Sergeant] unit.
+     *
+     * @param sergeant the sergeant to visit
+     */
+    fun visit(sergeant: Sergeant)
+
+    /**
+     * Visits a [Commander] unit.
+     *
+     * @param commander the commander to visit
+     */
+    fun visit(commander: Commander)
+}

--- a/visitor/src/test/kotlin/com/yonatankarp/visitor/AppTest.kt
+++ b/visitor/src/test/kotlin/com/yonatankarp/visitor/AppTest.kt
@@ -1,0 +1,12 @@
+package com.yonatankarp.visitor
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+/**
+ * Application test.
+ */
+internal class AppTest {
+    @Test
+    fun `should execute without exception`() = assertDoesNotThrow { main() }
+}

--- a/visitor/src/test/kotlin/com/yonatankarp/visitor/UnitTest.kt
+++ b/visitor/src/test/kotlin/com/yonatankarp/visitor/UnitTest.kt
@@ -1,0 +1,75 @@
+package com.yonatankarp.visitor
+
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the [Unit] hierarchy ensuring that each concrete unit
+ * correctly delegates to the visitor and propagates to children.
+ */
+internal class UnitTest {
+    @Test
+    fun `commander should visit itself then children`() {
+        // Given
+        val visitor = mockk<UnitVisitor>(relaxed = true)
+        val soldier = Soldier()
+        val sergeant = Sergeant(listOf(soldier))
+        val commander = Commander(listOf(sergeant))
+
+        // When
+        commander.accept(visitor)
+
+        // Then
+        verifyOrder {
+            visitor.visit(commander)
+            visitor.visit(sergeant)
+            visitor.visit(soldier)
+        }
+    }
+
+    @Test
+    fun `sergeant should visit itself then children`() {
+        // Given
+        val visitor = mockk<UnitVisitor>(relaxed = true)
+        val soldier1 = Soldier()
+        val soldier2 = Soldier()
+        val sergeant = Sergeant(listOf(soldier1, soldier2))
+
+        // When
+        sergeant.accept(visitor)
+
+        // Then
+        verifyOrder {
+            visitor.visit(sergeant)
+            visitor.visit(soldier1)
+            visitor.visit(soldier2)
+        }
+    }
+
+    @Test
+    fun `soldier should visit only itself`() {
+        val visitor = mockk<UnitVisitor>(relaxed = true)
+        val soldier = Soldier()
+
+        soldier.accept(visitor)
+
+        verify(exactly = 1) { visitor.visit(soldier) }
+    }
+
+    @Test
+    fun `commander toString should return commander`() {
+        assert(Commander().toString() == "commander")
+    }
+
+    @Test
+    fun `sergeant toString should return sergeant`() {
+        assert(Sergeant().toString() == "sergeant")
+    }
+
+    @Test
+    fun `soldier toString should return soldier`() {
+        assert(Soldier().toString() == "soldier")
+    }
+}

--- a/visitor/src/test/kotlin/com/yonatankarp/visitor/VisitorTest.kt
+++ b/visitor/src/test/kotlin/com/yonatankarp/visitor/VisitorTest.kt
@@ -1,0 +1,129 @@
+package com.yonatankarp.visitor
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * Verifies that each [UnitVisitor] implementation logs the
+ * expected message for the unit type it targets and stays silent
+ * for the others.
+ */
+internal class VisitorTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @ParameterizedTest(name = "{0} visiting commander")
+    @MethodSource("commanderVisitData")
+    fun `should log expected message when visiting commander`(
+        visitorName: String,
+        visitor: UnitVisitor,
+        expectedMessage: String?,
+    ) {
+        visitor.visit(Commander())
+        assertExpectedLog(expectedMessage)
+    }
+
+    @ParameterizedTest(name = "{0} visiting sergeant")
+    @MethodSource("sergeantVisitData")
+    fun `should log expected message when visiting sergeant`(
+        visitorName: String,
+        visitor: UnitVisitor,
+        expectedMessage: String?,
+    ) {
+        visitor.visit(Sergeant())
+        assertExpectedLog(expectedMessage)
+    }
+
+    @ParameterizedTest(name = "{0} visiting soldier")
+    @MethodSource("soldierVisitData")
+    fun `should log expected message when visiting soldier`(
+        visitorName: String,
+        visitor: UnitVisitor,
+        expectedMessage: String?,
+    ) {
+        visitor.visit(Soldier())
+        assertExpectedLog(expectedMessage)
+    }
+
+    private fun assertExpectedLog(expectedMessage: String?) {
+        if (expectedMessage != null) {
+            assertEquals(expectedMessage, appender.lastMessage)
+            assertEquals(1, appender.logSize)
+        } else {
+            assertEquals(0, appender.logSize)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun commanderVisitData() = listOf(
+            arrayOf<Any?>(
+                "CommanderVisitor",
+                CommanderVisitor(),
+                "Good to see you commander",
+            ),
+            arrayOf<Any?>(
+                "SergeantVisitor",
+                SergeantVisitor(),
+                null,
+            ),
+            arrayOf<Any?>(
+                "SoldierVisitor",
+                SoldierVisitor(),
+                null,
+            ),
+        )
+
+        @JvmStatic
+        fun sergeantVisitData() = listOf(
+            arrayOf<Any?>(
+                "CommanderVisitor",
+                CommanderVisitor(),
+                null,
+            ),
+            arrayOf<Any?>(
+                "SergeantVisitor",
+                SergeantVisitor(),
+                "Hello sergeant",
+            ),
+            arrayOf<Any?>(
+                "SoldierVisitor",
+                SoldierVisitor(),
+                null,
+            ),
+        )
+
+        @JvmStatic
+        fun soldierVisitData() = listOf(
+            arrayOf<Any?>(
+                "CommanderVisitor",
+                CommanderVisitor(),
+                null,
+            ),
+            arrayOf<Any?>(
+                "SergeantVisitor",
+                SergeantVisitor(),
+                null,
+            ),
+            arrayOf<Any?>(
+                "SoldierVisitor",
+                SoldierVisitor(),
+                "Greetings soldier",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Add Visitor design pattern implementation

Closes #411

- Ports the Visitor pattern from the Java reference repo to idiomatic Kotlin
- `Unit` sealed class hierarchy with `Commander`, `Sergeant`, `Soldier`
- `UnitVisitor` interface with overloaded `visit` methods
- Concrete visitors: `CommanderVisitor`, `SergeantVisitor`, `SoldierVisitor`
- Tests with MockK for accept delegation and InMemoryLoggerAppender for visitor output
- README with Mermaid class and sequence diagrams