### PR TITLE
Add Template Method design pattern implementation

### DIFF
--- a/template-method/README.md
+++ b/template-method/README.md
@@ -3,14 +3,236 @@ title: Template Method
 category: Behavioral
 language: en
 tag:
+  - Abstraction
+  - Code simplification
+  - Extensibility
   - Gang of Four
+  - Inheritance
+  - Polymorphism
 ---
+
+## Intent
+
+Define the skeleton of an algorithm in an operation,
+deferring some steps to subclasses. Template Method lets
+subclasses redefine certain steps of an algorithm without
+changing the algorithm's structure.
+
+## Explanation
+
+### Real-world example
+
+> A real-world analogy for the Template Method pattern can
+> be seen in the preparation of a cup of tea or coffee.
+> The overall process is the same: boil water, brew the
+> beverage, pour into a cup, and add condiments. However,
+> the specific brewing step differs. For tea you steep
+> leaves in hot water, while for coffee you brew ground
+> beans. The Template Method encapsulates the invariant
+> steps in a base class while allowing subclasses to
+> define the brewing step.
+
+### In plain words
+
+> Template Method outlines the core steps in the parent
+> class, allowing child classes to tailor the detailed
+> implementations.
+
+### Wikipedia says
+
+> In object-oriented programming, the template method is
+> one of the behavioral design patterns identified by
+> Gamma et al. in the book Design Patterns. The template
+> method is a method in a superclass, usually an abstract
+> superclass, and defines the skeleton of an operation in
+> terms of a number of high-level steps. These steps are
+> themselves implemented by additional helper methods in
+> the same class as the template method.
+
+### Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant HalflingThief
+    participant StealingMethod
+
+    Client->>HalflingThief: steal()
+    HalflingThief->>StealingMethod: steal()
+    StealingMethod->>StealingMethod: pickTarget()
+    StealingMethod->>StealingMethod: confuseTarget(target)
+    StealingMethod->>StealingMethod: stealTheItem(target)
+    StealingMethod-->>HalflingThief: done
+    HalflingThief-->>Client: done
+```
+
+### **Programmatic Example**
+
+The general steps in stealing an item are always the
+same. First you pick the target, then you confuse them,
+and finally you steal the item. However, there are many
+ways to implement these steps.
+
+Let's first introduce the template method class
+`StealingMethod` along with its concrete implementations
+`SubtleMethod` and `HitAndRunMethod`. Because Kotlin
+methods are final by default, the template method
+`steal()` cannot be overridden by subclasses.
+
+```kotlin
+abstract class StealingMethod {
+
+    protected abstract fun pickTarget(): String
+    protected abstract fun confuseTarget(target: String)
+    protected abstract fun stealTheItem(target: String)
+
+    fun steal() {
+        val target = pickTarget()
+        logger.info("The target has been chosen as $target.")
+        confuseTarget(target)
+        stealTheItem(target)
+    }
+}
+```
+
+```kotlin
+internal class SubtleMethod : StealingMethod() {
+  private val logger = LoggerFactory.getLogger(javaClass)
+
+  override fun pickTarget(): String = "shop keeper"
+
+  override fun confuseTarget(target: String) {
+    logger.info("Approach the $target with tears running and hug him!")
+  }
+
+  override fun stealTheItem(target: String) {
+    logger.info("While in close contact grab the $target's wallet.")
+  }
+}
+```
+
+```kotlin
+internal class HitAndRunMethod : StealingMethod() {
+
+    override fun pickTarget(): String = "old goblin woman"
+
+    override fun confuseTarget(target: String) {
+        logger.info("Approach the $target from behind.")
+    }
+
+    override fun stealTheItem(target: String) {
+        logger.info("Grab the handbag and run away fast!")
+    }
+}
+```
+
+Here is the `HalflingThief` class that uses a
+`StealingMethod`.
+
+```kotlin
+internal class HalflingThief(
+    private var method: StealingMethod,
+) {
+    fun steal() {
+        method.steal()
+    }
+
+    fun changeMethod(method: StealingMethod) {
+        this.method = method
+    }
+}
+```
+
+And finally, here is the halfling thief in action.
+
+```kotlin
+val thief = HalflingThief(HitAndRunMethod())
+thief.steal()
+thief.changeMethod(SubtleMethod())
+thief.steal()
+```
+
+Program output:
+
+```text
+The target has been chosen as old goblin woman.
+Approach the old goblin woman from behind.
+Grab the handbag and run away fast!
+The target has been chosen as shop keeper.
+Approach the shop keeper with tears running and hug him!
+While in close contact grab the shop keeper's wallet.
+```
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    class App {
-        +main(args String[])$
+    class StealingMethod {
+        <<abstract>>
+        #pickTarget() String
+        #confuseTarget(target String)
+        #stealTheItem(target String)
+        +steal()
     }
+    class HitAndRunMethod {
+        #pickTarget() String
+        #confuseTarget(target String)
+        #stealTheItem(target String)
+    }
+    class SubtleMethod {
+        #pickTarget() String
+        #confuseTarget(target String)
+        #stealTheItem(target String)
+    }
+    class HalflingThief {
+        -method StealingMethod
+        +steal()
+        +changeMethod(method StealingMethod)
+    }
+    HalflingThief --> StealingMethod : method
+    HitAndRunMethod --|> StealingMethod
+    SubtleMethod --|> StealingMethod
 ```
+
+## Applicability
+
+Use the Template Method pattern when:
+
+- You want to implement the invariant parts of an
+  algorithm once and leave it up to subclasses to
+  implement the behaviour that can vary.
+- Common behaviour among subclasses should be factored
+  and localised in a common class to avoid code
+  duplication.
+- You want to control subclass extensions by defining
+  a template method that calls hook operations at
+  specific points, permitting extensions only at those
+  points.
+
+## Consequences
+
+Benefits:
+
+- Promotes code reuse by defining invariant parts of an
+  algorithm in a base class.
+- Simplifies code maintenance by encapsulating common
+  behaviour in one place.
+- Enhances flexibility by allowing subclasses to override
+  specific steps of an algorithm.
+
+Trade-offs:
+
+- Can lead to an increase in the number of classes,
+  making the system more complex.
+- Requires careful design to ensure that the steps
+  exposed to subclasses are useful and meaningful.
+
+## Credits
+
+- [Design Patterns: Elements of Reusable
+  Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Effective Java](https://amzn.to/4cGk2Jz)
+- [Head First Design Patterns: Building Extensible and
+  Maintainable Object-Oriented
+  Software](https://amzn.to/49NGldq)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/template-method/build.gradle.kts
+++ b/template-method/build.gradle.kts
@@ -2,9 +2,20 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply true
 }
 
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/yonatankarp/kotlin-junit-tools")
+        credentials {
+            username = project.findProperty("gpr.user")?.toString() ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key")?.toString() ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
 dependencies {
     implementation(libs.bundles.kotlin.all)
     implementation(libs.bundles.log.all)
+    testImplementation(libs.kotlin.junit.tools)
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.tests.all)
 }

--- a/template-method/src/main/kotlin/com/yonatankarp/templatemethod/App.kt
+++ b/template-method/src/main/kotlin/com/yonatankarp/templatemethod/App.kt
@@ -1,0 +1,25 @@
+package com.yonatankarp.templatemethod
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Template Method defines the skeleton of an algorithm in a method,
+ * deferring some steps to subclasses. It lets subclasses redefine
+ * certain steps without changing the algorithm's structure.
+ *
+ * In this example [HalflingThief] uses a [StealingMethod] whose
+ * concrete steps vary between [HitAndRunMethod] and [SubtleMethod].
+ */
+
+internal val logger =
+    LoggerFactory.getLogger("com.yonatankarp.templatemethod")
+
+/**
+ * Program entry point.
+ */
+fun main() {
+    val thief = HalflingThief(HitAndRunMethod())
+    thief.steal()
+    thief.changeMethod(SubtleMethod())
+    thief.steal()
+}

--- a/template-method/src/main/kotlin/com/yonatankarp/templatemethod/HalflingThief.kt
+++ b/template-method/src/main/kotlin/com/yonatankarp/templatemethod/HalflingThief.kt
@@ -1,0 +1,26 @@
+package com.yonatankarp.templatemethod
+
+/**
+ * A halfling thief that uses a [StealingMethod] to steal.
+ *
+ * The method can be swapped at runtime via [changeMethod],
+ * demonstrating how the Template Method pattern decouples the
+ * algorithm skeleton from its concrete steps.
+ */
+internal class HalflingThief(private var method: StealingMethod) {
+    /**
+     * Executes the current stealing method.
+     */
+    fun steal() {
+        method.steal()
+    }
+
+    /**
+     * Replaces the current stealing method with the given [method].
+     *
+     * @param method the new stealing method to use
+     */
+    fun changeMethod(method: StealingMethod) {
+        this.method = method
+    }
+}

--- a/template-method/src/main/kotlin/com/yonatankarp/templatemethod/HitAndRunMethod.kt
+++ b/template-method/src/main/kotlin/com/yonatankarp/templatemethod/HitAndRunMethod.kt
@@ -1,0 +1,23 @@
+package com.yonatankarp.templatemethod
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A hit-and-run implementation of [StealingMethod].
+ *
+ * The thief approaches the target from behind, grabs the item, and
+ * runs away as fast as possible.
+ */
+internal class HitAndRunMethod : StealingMethod() {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun pickTarget(): String = "old goblin woman"
+
+    override fun confuseTarget(target: String) {
+        logger.info("Approach the $target from behind.")
+    }
+
+    override fun stealTheItem(target: String) {
+        logger.info("Grab the handbag and run away fast!")
+    }
+}

--- a/template-method/src/main/kotlin/com/yonatankarp/templatemethod/StealingMethod.kt
+++ b/template-method/src/main/kotlin/com/yonatankarp/templatemethod/StealingMethod.kt
@@ -1,0 +1,49 @@
+package com.yonatankarp.templatemethod
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Defines the skeleton of a stealing algorithm, deferring specific
+ * steps to subclasses.
+ *
+ * The [steal] method is the template method that orchestrates the
+ * invariant sequence: pick a target, confuse the target, then steal
+ * the item. Subclasses provide the concrete behaviour for each step.
+ */
+abstract class StealingMethod {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Selects the target to steal from.
+     *
+     * @return the name of the chosen target
+     */
+    protected abstract fun pickTarget(): String
+
+    /**
+     * Distracts or confuses the [target] so the theft can succeed.
+     *
+     * @param target the name of the target
+     */
+    protected abstract fun confuseTarget(target: String)
+
+    /**
+     * Steals the item from the [target].
+     *
+     * @param target the name of the target
+     */
+    protected abstract fun stealTheItem(target: String)
+
+    /**
+     * Template method that defines the stealing algorithm.
+     *
+     * Calls [pickTarget], [confuseTarget], and [stealTheItem] in
+     * sequence.
+     */
+    fun steal() {
+        val target = pickTarget()
+        logger.info("The target has been chosen as $target.")
+        confuseTarget(target)
+        stealTheItem(target)
+    }
+}

--- a/template-method/src/main/kotlin/com/yonatankarp/templatemethod/SubtleMethod.kt
+++ b/template-method/src/main/kotlin/com/yonatankarp/templatemethod/SubtleMethod.kt
@@ -1,0 +1,23 @@
+package com.yonatankarp.templatemethod
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A subtle implementation of [StealingMethod].
+ *
+ * The thief approaches the target with a tearful hug and picks
+ * their pocket during the embrace.
+ */
+internal class SubtleMethod : StealingMethod() {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun pickTarget(): String = "shop keeper"
+
+    override fun confuseTarget(target: String) {
+        logger.info("Approach the $target with tears running and hug him!")
+    }
+
+    override fun stealTheItem(target: String) {
+        logger.info("While in close contact grab the $target's wallet.")
+    }
+}

--- a/template-method/src/test/kotlin/com/yonatankarp/templatemethod/AppTest.kt
+++ b/template-method/src/test/kotlin/com/yonatankarp/templatemethod/AppTest.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.templatemethod
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the application entry point.
+ */
+internal class AppTest {
+    @Test
+    fun `should execute without exception`() {
+        assertDoesNotThrow { main() }
+    }
+}

--- a/template-method/src/test/kotlin/com/yonatankarp/templatemethod/HalflingThiefTest.kt
+++ b/template-method/src/test/kotlin/com/yonatankarp/templatemethod/HalflingThiefTest.kt
@@ -1,0 +1,37 @@
+package com.yonatankarp.templatemethod
+
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [HalflingThief].
+ */
+internal class HalflingThiefTest {
+    @Test
+    fun `should delegate steal to the current method`() {
+        val method = spyk(HitAndRunMethod())
+        val thief = HalflingThief(method)
+
+        thief.steal()
+
+        verify { method.steal() }
+    }
+
+    @Test
+    fun `should use new method after change`() {
+        // Given
+        val initialMethod = spyk(HitAndRunMethod())
+        val thief = HalflingThief(initialMethod)
+        thief.steal()
+        verify { initialMethod.steal() }
+
+        // When
+        val newMethod = spyk(SubtleMethod())
+        thief.changeMethod(newMethod)
+        thief.steal()
+
+        // Then
+        verify { newMethod.steal() }
+    }
+}

--- a/template-method/src/test/kotlin/com/yonatankarp/templatemethod/StealingMethodTest.kt
+++ b/template-method/src/test/kotlin/com/yonatankarp/templatemethod/StealingMethodTest.kt
@@ -1,0 +1,70 @@
+package com.yonatankarp.templatemethod
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * Parameterized tests for all [StealingMethod] implementations.
+ */
+internal class StealingMethodTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @ParameterizedTest
+    @MethodSource("stealingMethods")
+    fun `should execute the full steal sequence`(
+        testCase: StealingMethodTestCase,
+    ) {
+        // When
+        testCase.method.steal()
+
+        // Then
+        assertTrue(appender.logContains(testCase.expectedTarget))
+        assertTrue(appender.logContains(testCase.expectedConfuse))
+        assertTrue(appender.logContains(testCase.expectedSteal))
+    }
+
+    companion object {
+        @JvmStatic
+        fun stealingMethods() = listOf(
+            StealingMethodTestCase(
+                method = SubtleMethod(),
+                expectedTarget = "The target has been chosen as shop keeper.",
+                expectedConfuse = "Approach the shop keeper with tears running and hug him!",
+                expectedSteal = "While in close contact grab the shop keeper's wallet.",
+            ),
+            StealingMethodTestCase(
+                method = HitAndRunMethod(),
+                expectedTarget = "The target has been chosen as old goblin woman.",
+                expectedConfuse = "Approach the old goblin woman from behind.",
+                expectedSteal = "Grab the handbag and run away fast!",
+            ),
+        )
+    }
+}
+
+/**
+ * Holds the test data for a single [StealingMethod] variant.
+ */
+internal data class StealingMethodTestCase(
+    val method: StealingMethod,
+    val expectedTarget: String,
+    val expectedConfuse: String,
+    val expectedSteal: String,
+) {
+    override fun toString() = method.javaClass.simpleName
+}


### PR DESCRIPTION
Add Template Method design pattern implementation

Closes #412

- Ports the Template Method pattern from the Java reference repo to idiomatic Kotlin
- Abstract `StealingMethod` defines the template with `steal()` orchestrating `pickTarget`, `confuseTarget`, `stealTheItem`
- `SubtleMethod` and `HitAndRunMethod` as concrete strategies
- `HalflingThief` context class that delegates to a swappable `StealingMethod`
- Tests use InMemoryLoggerAppender to verify log output from the template sequence
- README with Mermaid class diagram and programmatic example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Template Method docs with intent, explanation, diagrams, programmatic example, applicability, consequences, and credits.

* **New Features**
  * Added a Template Method example demonstrating runtime strategy swapping and a runnable entry scenario.

* **Tests**
  * Added unit and parameterized tests verifying template workflow and delegation; added an execution smoke test.

* **Chores**
  * Added test dependency configuration to support the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->