### PR TITLE
Add Observer design pattern implementation

### DIFF
--- a/observer/README.md
+++ b/observer/README.md
@@ -3,14 +3,291 @@ title: Observer
 category: Behavioral
 language: en
 tag:
+  - Decoupling
+  - Event-driven
   - Gang of Four
+  - Publish/subscribe
 ---
+
+## Also known as
+
+- Dependents
+
+## Intent
+
+Define a one-to-many dependency between objects so
+that when one object changes state, all its dependents
+are notified and updated automatically.
+
+## Explanation
+
+### Real-world example
+
+> In a land far away live the races of hobbits and
+> orcs. Both of them are mostly outdoors, so they
+> closely follow the weather changes. One could say
+> they are constantly observing the weather.
+
+### In plain words
+
+> Register as an observer to receive state changes
+> from the subject you are interested in.
+
+### Wikipedia says
+
+> The observer pattern is a software design pattern in
+> which an object, called the subject, maintains a list
+> of its dependents, called observers, and notifies
+> them automatically of any state changes, usually by
+> calling one of their methods.
+
+### Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Weather
+    participant Orcs
+    participant Hobbits
+    Weather->>Weather: timePasses()
+    Weather->>Orcs: update(WeatherType)
+    Weather->>Hobbits: update(WeatherType)
+```
+
+### **Programmatic Example**
+
+Let's first introduce the `WeatherObserver` functional
+interface and our races, `Orcs` and `Hobbits`.
+
+```kotlin
+fun interface WeatherObserver {
+    fun update(currentWeather: WeatherType)
+}
+
+internal class Orcs : WeatherObserver {
+    private val logger =
+        LoggerFactory.getLogger(javaClass)
+
+    override fun update(currentWeather: WeatherType) {
+        logger.info(
+            "The orcs are facing {} weather now",
+            currentWeather.description,
+        )
+    }
+}
+
+internal class Hobbits : WeatherObserver {
+    private val logger =
+        LoggerFactory.getLogger(javaClass)
+
+    override fun update(currentWeather: WeatherType) {
+        logger.info(
+            "The hobbits are facing {} weather now",
+            currentWeather.description,
+        )
+    }
+}
+```
+
+Then here is the `Weather` that is constantly changing.
+
+```kotlin
+class Weather {
+    private val logger =
+        LoggerFactory.getLogger(javaClass)
+
+    private val observers =
+        mutableListOf<WeatherObserver>()
+    private var currentWeather = WeatherType.SUNNY
+
+    fun addObserver(observer: WeatherObserver) {
+        observers.add(observer)
+    }
+
+    fun removeObserver(observer: WeatherObserver) {
+        observers.remove(observer)
+    }
+
+    fun timePasses() {
+        val values = WeatherType.entries
+        currentWeather =
+            values[
+                (currentWeather.ordinal + 1) % values.size,
+            ]
+        logger.info(
+            "The weather changed to {}.",
+            currentWeather,
+        )
+        notifyObservers()
+    }
+
+    private fun notifyObservers() {
+        observers.forEach { it.update(currentWeather) }
+    }
+}
+```
+
+Here is the full example in action.
+
+```kotlin
+val weather = Weather()
+weather.addObserver(Orcs())
+weather.addObserver(Hobbits())
+
+weather.timePasses()
+weather.timePasses()
+weather.timePasses()
+weather.timePasses()
+```
+
+Program output:
+
+```text
+The weather changed to rainy.
+The orcs are facing Rainy weather now
+The hobbits are facing Rainy weather now
+The weather changed to windy.
+The orcs are facing Windy weather now
+The hobbits are facing Windy weather now
+The weather changed to cold.
+The orcs are facing Cold weather now
+The hobbits are facing Cold weather now
+The weather changed to sunny.
+The orcs are facing Sunny weather now
+The hobbits are facing Sunny weather now
+```
+
+A generic-observer variant uses type parameters so that
+the observer receives both the subject reference and an
+argument describing the change:
+
+```kotlin
+fun interface Observer<S, A> {
+    fun update(subject: S, argument: A)
+}
+
+abstract class Observable<S : Observable<S, A>, A> {
+    private val observers =
+        mutableListOf<Observer<S, A>>()
+
+    fun addObserver(observer: Observer<S, A>) {
+        observers.add(observer)
+    }
+
+    fun removeObserver(observer: Observer<S, A>) {
+        observers.remove(observer)
+    }
+
+    fun notifyObservers(argument: A) {
+        observers.forEach {
+            it.update(this as S, argument)
+        }
+    }
+}
+```
 
 ## Class diagram
 
 ```mermaid
 classDiagram
-    class App {
-        +main(args String[])$
+    class WeatherType {
+        <<enumeration>>
+        COLD
+        RAINY
+        SUNNY
+        WINDY
+        +description String
+        +toString() String
     }
+    class WeatherObserver {
+        <<fun interface>>
+        +update(WeatherType)
+    }
+    class Weather {
+        -observers MutableList~WeatherObserver~
+        -currentWeather WeatherType
+        +addObserver(WeatherObserver)
+        +removeObserver(WeatherObserver)
+        +timePasses()
+        -notifyObservers()
+    }
+    class Hobbits {
+        +update(WeatherType)
+    }
+    class Orcs {
+        +update(WeatherType)
+    }
+    Weather --> WeatherObserver : notifies
+    Hobbits ..|> WeatherObserver
+    Orcs ..|> WeatherObserver
+
+    class Observer~S, A~ {
+        <<fun interface>>
+        +update(S, A)
+    }
+    class Observable~S, A~ {
+        <<abstract>>
+        -observers MutableList~Observer~
+        +addObserver(Observer)
+        +removeObserver(Observer)
+        +notifyObservers(A)
+    }
+    class Race {
+        <<fun interface>>
+    }
+    class GenWeather {
+        -currentWeather WeatherType
+        +timePasses()
+    }
+    class GenHobbits {
+        +update(GenWeather, WeatherType)
+    }
+    class GenOrcs {
+        +update(GenWeather, WeatherType)
+    }
+    GenWeather --|> Observable
+    Race --|> Observer
+    GenHobbits ..|> Race
+    GenOrcs ..|> Race
 ```
+
+## Applicability
+
+Use the Observer pattern when:
+
+- An abstraction has two aspects, one dependent on
+  the other. Encapsulating these aspects in separate
+  objects lets you vary and reuse them independently.
+- A change to one object requires changing others,
+  and you don't know how many objects need changing.
+- An object should be able to notify other objects
+  without making assumptions about who those objects
+  are -- you don't want these objects tightly coupled.
+
+## Consequences
+
+Benefits:
+
+- Promotes loose coupling between the subject and its
+  observers.
+- Allows dynamic subscription and unsubscription of
+  observers at runtime.
+
+Trade-offs:
+
+- Can lead to memory leaks if observers are not
+  properly deregistered.
+- The order of notification is not specified, which
+  may lead to unexpected behaviour.
+- Potential for performance issues with a large number
+  of observers.
+
+## Credits
+
+- [Design Patterns: Elements of Reusable
+  Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Java Generics and
+  Collections](https://amzn.to/3VhOBxp)
+- [Head First Design Patterns: Building Extensible
+  and Maintainable Object-Oriented
+  Software](https://amzn.to/49NGldq)
+- [Refactoring to Patterns](https://amzn.to/3VOO4F5)

--- a/observer/build.gradle.kts
+++ b/observer/build.gradle.kts
@@ -2,9 +2,20 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply true
 }
 
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/yonatankarp/kotlin-junit-tools")
+        credentials {
+            username = project.findProperty("gpr.user")?.toString() ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key")?.toString() ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
 dependencies {
     implementation(libs.bundles.kotlin.all)
     implementation(libs.bundles.log.all)
+    testImplementation(libs.kotlin.junit.tools)
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.tests.all)
 }

--- a/observer/src/main/kotlin/com/yonatankarp/observer/Hobbits.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/Hobbits.kt
@@ -1,0 +1,15 @@
+package com.yonatankarp.observer
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A [WeatherObserver] representing the hobbits, who react to
+ * weather changes.
+ */
+internal class Hobbits : WeatherObserver {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun update(currentWeather: WeatherType) {
+        logger.info("The hobbits are facing ${currentWeather.description} weather now")
+    }
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/Orcs.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/Orcs.kt
@@ -1,0 +1,15 @@
+package com.yonatankarp.observer
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A [WeatherObserver] representing the orcs, who react to
+ * weather changes.
+ */
+internal class Orcs : WeatherObserver {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun update(currentWeather: WeatherType) {
+        logger.info("The orcs are facing ${currentWeather.description} weather now")
+    }
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/Weather.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/Weather.kt
@@ -1,0 +1,44 @@
+package com.yonatankarp.observer
+
+import org.slf4j.LoggerFactory
+
+/**
+ * The subject in the Observer pattern. [Weather] maintains a list of
+ * [WeatherObserver] instances and notifies them whenever the weather
+ * changes via [timePasses].
+ */
+class Weather {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val observers = mutableListOf<WeatherObserver>()
+    private var currentWeather = WeatherType.SUNNY
+
+    /**
+     * Registers an [observer] to receive weather updates.
+     */
+    fun addObserver(observer: WeatherObserver) {
+        observers.add(observer)
+    }
+
+    /**
+     * Unregisters an [observer] so it no longer receives updates.
+     */
+    fun removeObserver(observer: WeatherObserver) {
+        observers.remove(observer)
+    }
+
+    /**
+     * Advances the weather to the next [WeatherType] in the cycle
+     * and notifies all registered observers.
+     */
+    fun timePasses() {
+        val values = WeatherType.entries
+        currentWeather = values[(currentWeather.ordinal + 1) % values.size]
+        logger.info("The weather changed to $currentWeather.")
+        notifyObservers()
+    }
+
+    private fun notifyObservers() {
+        observers.forEach { it.update(currentWeather) }
+    }
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/WeatherObserver.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/WeatherObserver.kt
@@ -1,0 +1,13 @@
+package com.yonatankarp.observer
+
+/**
+ * Functional interface for observing [WeatherType] changes.
+ */
+fun interface WeatherObserver {
+    /**
+     * Called when the observed weather changes.
+     *
+     * @param currentWeather the new [WeatherType]
+     */
+    fun update(currentWeather: WeatherType)
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/WeatherType.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/WeatherType.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.observer
+
+/**
+ * Enumerates the possible weather conditions that can be observed.
+ */
+enum class WeatherType(val description: String) {
+    COLD("Cold"),
+    RAINY("Rainy"),
+    SUNNY("Sunny"),
+    WINDY("Windy"),
+    ;
+
+    override fun toString() = name.lowercase()
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/generic/GenHobbits.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/generic/GenHobbits.kt
@@ -1,0 +1,16 @@
+package com.yonatankarp.observer.generic
+
+import com.yonatankarp.observer.WeatherType
+import org.slf4j.LoggerFactory
+
+/**
+ * A [Race] observer representing the hobbits in the
+ * generic-observer variant.
+ */
+internal class GenHobbits : Race {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun update(subject: GenWeather, argument: WeatherType) {
+        logger.info("The hobbits are facing ${argument.description} weather now")
+    }
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/generic/GenOrcs.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/generic/GenOrcs.kt
@@ -1,0 +1,16 @@
+package com.yonatankarp.observer.generic
+
+import com.yonatankarp.observer.WeatherType
+import org.slf4j.LoggerFactory
+
+/**
+ * A [Race] observer representing the orcs in the
+ * generic-observer variant.
+ */
+internal class GenOrcs : Race {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun update(subject: GenWeather, argument: WeatherType) {
+        logger.info("The orcs are facing ${argument.description} weather now")
+    }
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/generic/GenWeather.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/generic/GenWeather.kt
@@ -1,0 +1,29 @@
+package com.yonatankarp.observer.generic
+
+import com.yonatankarp.observer.WeatherType
+import org.slf4j.LoggerFactory
+
+/**
+ * Generic-observer variant of the weather subject.
+ *
+ * Extends [Observable] so that registered [Race] observers are
+ * notified with both the subject reference and the new
+ * [WeatherType] whenever [timePasses] is called.
+ */
+class GenWeather :
+    Observable<GenWeather, WeatherType>() {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private var currentWeather = WeatherType.SUNNY
+
+    /**
+     * Advances the weather to the next [WeatherType] in the
+     * cycle and notifies all registered observers.
+     */
+    fun timePasses() {
+        val values = WeatherType.entries
+        currentWeather =
+            values[(currentWeather.ordinal + 1) % values.size]
+        logger.info("The weather changed to $currentWeather.")
+        notifyObservers(currentWeather)
+    }
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/generic/Observable.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/generic/Observable.kt
@@ -1,0 +1,39 @@
+package com.yonatankarp.observer.generic
+
+/**
+ * Generic observable base class inspired by
+ * *Java Generics and Collections* (Naftalin and Wadler).
+ *
+ * Subclasses specify their own type [S] so that observers receive
+ * a correctly-typed reference to the subject, along with an
+ * argument of type [A].
+ *
+ * @param S the concrete subject type (self-type)
+ * @param A the argument type passed to observers on notification
+ */
+@Suppress("UNCHECKED_CAST")
+open class Observable<S : Observable<S, A>, A> {
+    private val observers = mutableListOf<Observer<S, A>>()
+
+    /**
+     * Registers an [observer] to receive notifications.
+     */
+    fun addObserver(observer: Observer<S, A>) {
+        observers.add(observer)
+    }
+
+    /**
+     * Unregisters an [observer] so it no longer receives
+     * notifications.
+     */
+    fun removeObserver(observer: Observer<S, A>) {
+        observers.remove(observer)
+    }
+
+    /**
+     * Notifies every registered observer with the given [argument].
+     */
+    fun notifyObservers(argument: A) {
+        observers.forEach { it.update(this as S, argument) }
+    }
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/generic/Observer.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/generic/Observer.kt
@@ -1,0 +1,13 @@
+package com.yonatankarp.observer.generic
+
+/**
+ * Generic observer interface parameterised by the subject type [S]
+ * and the argument type [A] passed during notifications.
+ */
+fun interface Observer<S, A> {
+    /**
+     * Called when [subject] changes, with [argument] describing the
+     * change.
+     */
+    fun update(subject: S, argument: A)
+}

--- a/observer/src/main/kotlin/com/yonatankarp/observer/generic/Race.kt
+++ b/observer/src/main/kotlin/com/yonatankarp/observer/generic/Race.kt
@@ -1,0 +1,10 @@
+package com.yonatankarp.observer.generic
+
+import com.yonatankarp.observer.WeatherType
+
+/**
+ * A type alias binding [Observer] to the weather domain:
+ * observes [GenWeather] subjects and receives [WeatherType]
+ * arguments.
+ */
+fun interface Race : Observer<GenWeather, WeatherType>

--- a/observer/src/test/kotlin/com/yonatankarp/observer/HobbitsTest.kt
+++ b/observer/src/test/kotlin/com/yonatankarp/observer/HobbitsTest.kt
@@ -1,0 +1,60 @@
+package com.yonatankarp.observer
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class HobbitsTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataProvider")
+    fun `should log correct message for weather type`(
+        weather: WeatherType,
+        expectedMessage: String,
+    ) {
+        // When
+        Hobbits().update(weather)
+
+        // Then
+        assertEquals(expectedMessage, appender.lastMessage)
+        assertEquals(1, appender.logSize)
+    }
+
+    companion object {
+        @JvmStatic
+        fun dataProvider() =
+            listOf(
+                arrayOf<Any>(
+                    WeatherType.COLD,
+                    "The hobbits are facing Cold weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.RAINY,
+                    "The hobbits are facing Rainy weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.SUNNY,
+                    "The hobbits are facing Sunny weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.WINDY,
+                    "The hobbits are facing Windy weather now",
+                ),
+            )
+    }
+}

--- a/observer/src/test/kotlin/com/yonatankarp/observer/OrcsTest.kt
+++ b/observer/src/test/kotlin/com/yonatankarp/observer/OrcsTest.kt
@@ -1,0 +1,60 @@
+package com.yonatankarp.observer
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class OrcsTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataProvider")
+    fun `should log correct message for weather type`(
+        weather: WeatherType,
+        expectedMessage: String,
+    ) {
+        // When
+        Orcs().update(weather)
+
+        // Then
+        assertEquals(expectedMessage, appender.lastMessage)
+        assertEquals(1, appender.logSize)
+    }
+
+    companion object {
+        @JvmStatic
+        fun dataProvider() =
+            listOf(
+                arrayOf<Any>(
+                    WeatherType.COLD,
+                    "The orcs are facing Cold weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.RAINY,
+                    "The orcs are facing Rainy weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.SUNNY,
+                    "The orcs are facing Sunny weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.WINDY,
+                    "The orcs are facing Windy weather now",
+                ),
+            )
+    }
+}

--- a/observer/src/test/kotlin/com/yonatankarp/observer/WeatherTest.kt
+++ b/observer/src/test/kotlin/com/yonatankarp/observer/WeatherTest.kt
@@ -1,0 +1,76 @@
+package com.yonatankarp.observer
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class WeatherTest {
+    private val appender = InMemoryLoggerAppender(Weather::class.java)
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @Test
+    fun `should notify observer on weather change and stop after removal`() {
+        // Given
+        val observer = mockk<WeatherObserver>(relaxed = true)
+        val weather = Weather()
+        weather.addObserver(observer)
+
+        // When — SUNNY -> WINDY
+        weather.timePasses()
+
+        // Then
+        assertEquals(
+            "The weather changed to windy.",
+            appender.lastMessage,
+        )
+        verify { observer.update(WeatherType.WINDY) }
+
+        // When — remove observer, WINDY -> COLD
+        weather.removeObserver(observer)
+        weather.timePasses()
+
+        // Then
+        assertEquals(
+            "The weather changed to cold.",
+            appender.lastMessage,
+        )
+        verify(exactly = 1) { observer.update(any()) }
+        assertEquals(2, appender.logSize)
+    }
+
+    @Test
+    fun `should cycle through all weather types in order`() {
+        // Given
+        val observer = mockk<WeatherObserver>(relaxed = true)
+        val weather = Weather()
+        weather.addObserver(observer)
+        val weatherTypes = WeatherType.entries
+        val startIndex = WeatherType.SUNNY.ordinal
+
+        // When
+        repeat(weatherTypes.size) { weather.timePasses() }
+
+        // Then
+        weatherTypes.indices.forEach { i ->
+            verify {
+                observer.update(
+                    weatherTypes[(startIndex + i + 1) % weatherTypes.size],
+                )
+            }
+        }
+    }
+}

--- a/observer/src/test/kotlin/com/yonatankarp/observer/generic/GenHobbitsTest.kt
+++ b/observer/src/test/kotlin/com/yonatankarp/observer/generic/GenHobbitsTest.kt
@@ -1,0 +1,61 @@
+package com.yonatankarp.observer.generic
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import com.yonatankarp.observer.WeatherType
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class GenHobbitsTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataProvider")
+    fun `should log correct message for weather type`(
+        weather: WeatherType,
+        expectedMessage: String,
+    ) {
+        // When
+        GenHobbits().update(GenWeather(), weather)
+
+        // Then
+        assertEquals(expectedMessage, appender.lastMessage)
+        assertEquals(1, appender.logSize)
+    }
+
+    companion object {
+        @JvmStatic
+        fun dataProvider() =
+            listOf(
+                arrayOf<Any>(
+                    WeatherType.COLD,
+                    "The hobbits are facing Cold weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.RAINY,
+                    "The hobbits are facing Rainy weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.SUNNY,
+                    "The hobbits are facing Sunny weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.WINDY,
+                    "The hobbits are facing Windy weather now",
+                ),
+            )
+    }
+}

--- a/observer/src/test/kotlin/com/yonatankarp/observer/generic/GenOrcsTest.kt
+++ b/observer/src/test/kotlin/com/yonatankarp/observer/generic/GenOrcsTest.kt
@@ -1,0 +1,61 @@
+package com.yonatankarp.observer.generic
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import com.yonatankarp.observer.WeatherType
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class GenOrcsTest {
+    private val appender = InMemoryLoggerAppender()
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataProvider")
+    fun `should log correct message for weather type`(
+        weather: WeatherType,
+        expectedMessage: String,
+    ) {
+        // When
+        GenOrcs().update(GenWeather(), weather)
+
+        // Then
+        assertEquals(expectedMessage, appender.lastMessage)
+        assertEquals(1, appender.logSize)
+    }
+
+    companion object {
+        @JvmStatic
+        fun dataProvider() =
+            listOf(
+                arrayOf<Any>(
+                    WeatherType.COLD,
+                    "The orcs are facing Cold weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.RAINY,
+                    "The orcs are facing Rainy weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.SUNNY,
+                    "The orcs are facing Sunny weather now",
+                ),
+                arrayOf<Any>(
+                    WeatherType.WINDY,
+                    "The orcs are facing Windy weather now",
+                ),
+            )
+    }
+}

--- a/observer/src/test/kotlin/com/yonatankarp/observer/generic/GenWeatherTest.kt
+++ b/observer/src/test/kotlin/com/yonatankarp/observer/generic/GenWeatherTest.kt
@@ -1,0 +1,79 @@
+package com.yonatankarp.observer.generic
+
+import com.yonatankarp.kotlin.junit.tools.logger.InMemoryLoggerAppender
+import com.yonatankarp.observer.WeatherType
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class GenWeatherTest {
+    private val appender =
+        InMemoryLoggerAppender(GenWeather::class.java)
+
+    @BeforeEach
+    fun setUp() {
+        appender.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        appender.stop()
+        appender.clearAll()
+    }
+
+    @Test
+    fun `should notify observer on weather change and stop after removal`() {
+        // Given
+        val observer = mockk<Race>(relaxed = true)
+        val weather = GenWeather()
+        weather.addObserver(observer)
+
+        // When — SUNNY -> WINDY
+        weather.timePasses()
+
+        // Then
+        assertEquals(
+            "The weather changed to windy.",
+            appender.lastMessage,
+        )
+        verify { observer.update(weather, WeatherType.WINDY) }
+
+        // When — remove observer, WINDY -> COLD
+        weather.removeObserver(observer)
+        weather.timePasses()
+
+        // Then
+        assertEquals(
+            "The weather changed to cold.",
+            appender.lastMessage,
+        )
+        verify(exactly = 1) { observer.update(any(), any()) }
+        assertEquals(2, appender.logSize)
+    }
+
+    @Test
+    fun `should cycle through all weather types in order`() {
+        // Given
+        val observer = mockk<Race>(relaxed = true)
+        val weather = GenWeather()
+        weather.addObserver(observer)
+        val weatherTypes = WeatherType.entries
+        val startIndex = WeatherType.SUNNY.ordinal
+
+        // When
+        repeat(weatherTypes.size) { weather.timePasses() }
+
+        // Then
+        weatherTypes.indices.forEach { i ->
+            verify {
+                observer.update(
+                    weather,
+                    weatherTypes[(startIndex + i + 1) % weatherTypes.size],
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Observer design pattern implementation

Closes #413

- Ports the Observer pattern from the Java reference repo to idiomatic Kotlin
- Standard variant: `Weather` subject, `WeatherObserver` fun interface, `Hobbits`/`Orcs` observers
- Generic variant: `Observable<S, A>` base, `Observer<S, A>` fun interface, `Race` domain binding
- `WeatherType` enum with alphabetical entries and description property
- Kotlin string templates for logging throughout
- Comprehensive tests with MockK and InMemoryLoggerAppender
- README with Mermaid class diagram and programmatic example