### PR TITLE
Add Iterator design pattern implementation

### DIFF
--- a/iterator/README.md
+++ b/iterator/README.md
@@ -1,0 +1,326 @@
+---
+title: Iterator
+category: Behavioral
+language: en
+tag:
+  - Data access
+  - Data transformation
+  - Decoupling
+  - Gang of Four
+  - Object composition
+  - Polymorphism
+---
+
+## Also known as
+
+- Cursor
+
+## Intent
+
+Provide a way to access elements of an aggregate object
+sequentially without exposing its underlying representation.
+
+## Explanation
+
+### Real-world example
+
+> Imagine visiting a library with a vast collection of
+> books organized in different sections such as fiction,
+> non-fiction, science, etc. Instead of searching through
+> every shelf yourself, the librarian provides you with a
+> specific guidebook or a digital catalog for each section.
+> This guidebook acts as an "iterator," allowing you to go
+> through the books section by section, or even skip to
+> specific types of books, without needing to know how the
+> books are organized on the shelves.
+
+### In plain words
+
+> The Iterator pattern provides a method to sequentially
+> access elements of a collection without exposing its
+> underlying structure.
+
+### Wikipedia says
+
+> In object-oriented programming, the iterator pattern is
+> a design pattern in which an iterator is used to traverse
+> a container and access the container's elements.
+
+### Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant TreasureChest
+    participant TreasureChestItemIterator
+
+    Client ->> TreasureChest: iterator(itemType)
+    TreasureChest -->> Client: Iterator~Item~
+    loop hasNext()
+        Client ->> TreasureChestItemIterator: hasNext()
+        TreasureChestItemIterator -->> Client: true
+        Client ->> TreasureChestItemIterator: next()
+        TreasureChestItemIterator -->> Client: Item
+    end
+    Client ->> TreasureChestItemIterator: hasNext()
+    TreasureChestItemIterator -->> Client: false
+```
+
+### **Programmatic Example**
+
+The main class in our example is the `TreasureChest`
+that contains items.
+
+```kotlin
+data class Item(val type: ItemType, val name: String) {
+    override fun toString() = name
+}
+
+enum class ItemType {
+    ANY,
+    POTION,
+    RING,
+    WEAPON,
+    ;
+
+    override fun toString() = name.lowercase()
+}
+```
+
+The `TreasureChest` class stores items and returns a
+filtered iterator.
+
+```kotlin
+class TreasureChest {
+    private val items: List<Item> =
+        listOf(
+            Item(ItemType.POTION, "Potion of courage"),
+            Item(ItemType.RING, "Ring of shadows"),
+            Item(ItemType.POTION, "Potion of wisdom"),
+            Item(ItemType.POTION, "Potion of blood"),
+            Item(ItemType.WEAPON, "Sword of silver +1"),
+            Item(ItemType.POTION, "Potion of rust"),
+            Item(ItemType.POTION, "Potion of healing"),
+            Item(ItemType.RING, "Ring of armor"),
+            Item(ItemType.WEAPON, "Steel halberd"),
+            Item(ItemType.WEAPON, "Dagger of poison"),
+        )
+
+    fun iterator(itemType: ItemType): Iterator<Item> =
+        TreasureChestItemIterator(items, itemType)
+
+    fun getItems(): List<Item> = items.toList()
+}
+```
+
+The `TreasureChestItemIterator` implements Kotlin's
+built-in `Iterator` interface, filtering items by type.
+
+```kotlin
+internal class TreasureChestItemIterator(
+    private val items: List<Item>,
+    private val type: ItemType,
+) : Iterator<Item> {
+    private var idx = -1
+
+    override fun hasNext(): Boolean = findNextIdx() != -1
+
+    override fun next(): Item {
+        idx = findNextIdx()
+        check(idx != -1) { "No more items" }
+        return items[idx]
+    }
+
+    private fun findNextIdx(): Int {
+        var tempIdx = idx
+        while (true) {
+            tempIdx++
+            if (tempIdx >= items.size) return -1
+            if (type == ItemType.ANY ||
+                items[tempIdx].type == type
+            ) {
+                return tempIdx
+            }
+        }
+    }
+}
+```
+
+A second example demonstrates iteration over a binary
+search tree. The `TreeNode` class represents a BST node.
+
+```kotlin
+class TreeNode<T : Comparable<T>>(val value: T) {
+    var left: TreeNode<T>? = null
+        private set
+    var right: TreeNode<T>? = null
+        private set
+
+    fun insert(newValue: T) {
+        val parent = parentNodeFor(newValue)
+        parent.insertChild(newValue)
+    }
+
+    override fun toString(): String = value.toString()
+}
+```
+
+The `BstIterator` performs an in-order traversal using
+a stack, achieving O(h) extra space.
+
+```kotlin
+class BstIterator<T : Comparable<T>>(
+    root: TreeNode<T>?,
+) : Iterator<TreeNode<T>> {
+    private val pathStack = ArrayDeque<TreeNode<T>>()
+
+    init {
+        pushPathToNextSmallest(root)
+    }
+
+    override fun hasNext(): Boolean =
+        pathStack.isNotEmpty()
+
+    override fun next(): TreeNode<T> {
+        if (pathStack.isEmpty()) {
+            throw NoSuchElementException()
+        }
+        val next = pathStack.pop()
+        pushPathToNextSmallest(next.right)
+        return next
+    }
+}
+```
+
+Here is the full example in action.
+
+```kotlin
+val treasureChest = TreasureChest()
+
+logger.info("Item Iterator for ItemType ring: ")
+val ringIterator = treasureChest.iterator(ItemType.RING)
+ringIterator.forEach { logger.info(it.toString()) }
+
+logger.info("BST Iterator: ")
+val root = TreeNode(8).apply {
+    insert(3)
+    insert(10)
+    insert(1)
+    insert(6)
+    insert(14)
+    insert(4)
+    insert(7)
+    insert(13)
+}
+val bstIterator = BstIterator(root)
+bstIterator.forEach { logger.info("Next node: ${it.value}") }
+```
+
+Program output:
+
+```text
+Item Iterator for ItemType ring:
+Ring of shadows
+Ring of armor
+BST Iterator:
+Next node: 1
+Next node: 3
+Next node: 4
+Next node: 6
+Next node: 7
+Next node: 8
+Next node: 10
+Next node: 13
+Next node: 14
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class Iterator~T~ {
+        <<interface>>
+        +hasNext() Boolean
+        +next() T
+    }
+    class ItemType {
+        <<enumeration>>
+        ANY
+        POTION
+        RING
+        WEAPON
+        +toString() String
+    }
+    class Item {
+        +type ItemType
+        +name String
+        +toString() String
+    }
+    class TreasureChest {
+        -items List~Item~
+        +iterator(ItemType) Iterator~Item~
+        +getItems() List~Item~
+    }
+    class TreasureChestItemIterator {
+        -items List~Item~
+        -type ItemType
+        -idx Int
+        +hasNext() Boolean
+        +next() Item
+    }
+    class TreeNode~T~ {
+        +value T
+        +left TreeNode~T~
+        +right TreeNode~T~
+        +insert(T)
+        +toString() String
+    }
+    class BstIterator~T~ {
+        -pathStack ArrayDeque~TreeNode~
+        +hasNext() Boolean
+        +next() TreeNode~T~
+    }
+
+    TreasureChestItemIterator ..|> Iterator~Item~
+    BstIterator ..|> Iterator~TreeNode~
+    TreasureChest --> TreasureChestItemIterator : creates
+    TreasureChest o-- Item : contains
+    Item --> ItemType
+    BstIterator --> TreeNode : traverses
+```
+
+## Applicability
+
+Use the Iterator pattern when:
+
+- You need to access an aggregate object's contents
+  without exposing its internal representation.
+- You want to support multiple traversals of aggregate
+  objects.
+- You want to provide a uniform interface for traversing
+  different aggregate structures.
+
+## Consequences
+
+Benefits:
+
+- Reduces the coupling between data structures and
+  algorithms used for iteration.
+- Provides a uniform interface for iterating over various
+  types of data structures, enhancing code reusability
+  and flexibility.
+
+Trade-offs:
+
+- Overhead of using an iterator object may slightly
+  reduce performance compared to direct traversal.
+- Complex aggregate structures may require complex
+  iterators that can be difficult to manage or extend.
+
+## Credits
+
+- [Design Patterns: Elements of Reusable
+  Object-Oriented Software](https://amzn.to/3w0pvKI)
+- [Head First Design Patterns: Building Extensible and
+  Maintainable Object-Oriented
+  Software](https://amzn.to/49NGldq)

--- a/iterator/src/main/kotlin/com/yonatankarp/iterator/App.kt
+++ b/iterator/src/main/kotlin/com/yonatankarp/iterator/App.kt
@@ -1,0 +1,53 @@
+package com.yonatankarp.iterator
+
+import com.yonatankarp.iterator.bst.BstIterator
+import com.yonatankarp.iterator.bst.TreeNode
+import com.yonatankarp.iterator.list.ItemType
+import com.yonatankarp.iterator.list.TreasureChest
+import org.slf4j.LoggerFactory
+
+internal val logger =
+    LoggerFactory.getLogger("com.yonatankarp.iterator")
+
+private val treasureChest = TreasureChest()
+
+/**
+ * Program entry point demonstrating the Iterator pattern with
+ * both a [TreasureChest] item iterator and a [BstIterator].
+ */
+fun main() {
+    demonstrateTreasureChestIteratorForType(ItemType.RING)
+    demonstrateTreasureChestIteratorForType(ItemType.POTION)
+    demonstrateTreasureChestIteratorForType(ItemType.WEAPON)
+    demonstrateTreasureChestIteratorForType(ItemType.ANY)
+    demonstrateBstIterator()
+}
+
+private fun demonstrateTreasureChestIteratorForType(
+    itemType: ItemType,
+) {
+    logger.info("------------------------")
+    logger.info("Item Iterator for ItemType $itemType: ")
+    val itemIterator = treasureChest.iterator(itemType)
+    itemIterator.forEach { logger.info(it.toString()) }
+}
+
+private fun demonstrateBstIterator() {
+    logger.info("------------------------")
+    logger.info("BST Iterator: ")
+    val root = buildIntegerBst()
+    val bstIterator = BstIterator(root)
+    bstIterator.forEach { logger.info("Next node: ${it.value}") }
+}
+
+private fun buildIntegerBst(): TreeNode<Int> =
+    TreeNode(8).apply {
+        insert(3)
+        insert(10)
+        insert(1)
+        insert(6)
+        insert(14)
+        insert(4)
+        insert(7)
+        insert(13)
+    }

--- a/iterator/src/main/kotlin/com/yonatankarp/iterator/bst/BstIterator.kt
+++ b/iterator/src/main/kotlin/com/yonatankarp/iterator/bst/BstIterator.kt
@@ -1,0 +1,49 @@
+package com.yonatankarp.iterator.bst
+
+import java.util.ArrayDeque
+
+/**
+ * An in-order [Iterator] over a binary search tree of [TreeNode]
+ * elements.
+ *
+ * For a BST with integer values, nodes are returned in ascending
+ * natural order (1, 2, 3, ...).
+ *
+ * Uses O(h) extra space, where h is the height of the tree.
+ *
+ * @param T the comparable type stored in each [TreeNode]
+ * @param root the root of the BST (may be null for an empty tree)
+ */
+class BstIterator<T : Comparable<T>>(
+    root: TreeNode<T>?,
+) : Iterator<TreeNode<T>> {
+    private val pathStack = ArrayDeque<TreeNode<T>>()
+
+    init {
+        pushPathToNextSmallest(root)
+    }
+
+    override fun hasNext(): Boolean = pathStack.isNotEmpty()
+
+    /**
+     * Returns the next [TreeNode] in in-order traversal.
+     *
+     * @throws NoSuchElementException if there are no more elements
+     */
+    override fun next(): TreeNode<T> {
+        if (pathStack.isEmpty()) {
+            throw NoSuchElementException()
+        }
+        val next = pathStack.pop()
+        pushPathToNextSmallest(next.right)
+        return next
+    }
+
+    private fun pushPathToNextSmallest(node: TreeNode<T>?) {
+        var current = node
+        while (current != null) {
+            pathStack.push(current)
+            current = current.left
+        }
+    }
+}

--- a/iterator/src/main/kotlin/com/yonatankarp/iterator/bst/TreeNode.kt
+++ b/iterator/src/main/kotlin/com/yonatankarp/iterator/bst/TreeNode.kt
@@ -1,0 +1,52 @@
+package com.yonatankarp.iterator.bst
+
+/**
+ * A node in a binary search tree that holds a [Comparable] value.
+ *
+ * @param T the type of value stored in the node
+ * @property value the value held by this node
+ */
+class TreeNode<T : Comparable<T>>(val value: T) {
+    /**
+     * Left child (values less than [value]).
+     */
+    var left: TreeNode<T>? = null
+        private set
+
+    /**
+     * Right child (values greater than or equal to [value]).
+     */
+    var right: TreeNode<T>? = null
+        private set
+
+    /**
+     * Inserts a new value into the subtree rooted at this node.
+     *
+     * @param newValue the value to insert
+     */
+    fun insert(newValue: T) {
+        val parent = parentNodeFor(newValue)
+        parent.insertChild(newValue)
+    }
+
+    private fun parentNodeFor(target: T): TreeNode<T> {
+        var parent = this
+        var current: TreeNode<T>? = this
+        while (current != null) {
+            parent = current
+            current =
+                if (current.value > target) current.left else current.right
+        }
+        return parent
+    }
+
+    private fun insertChild(newValue: T) {
+        if (value <= newValue) {
+            right = TreeNode(newValue)
+        } else {
+            left = TreeNode(newValue)
+        }
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/iterator/src/main/kotlin/com/yonatankarp/iterator/list/Item.kt
+++ b/iterator/src/main/kotlin/com/yonatankarp/iterator/list/Item.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.iterator.list
+
+/**
+ * Represents a single item stored inside a [TreasureChest].
+ *
+ * @property type the category of this item
+ * @property name the display name of this item
+ */
+data class Item(val type: ItemType, val name: String) {
+    override fun toString() = name
+}

--- a/iterator/src/main/kotlin/com/yonatankarp/iterator/list/ItemType.kt
+++ b/iterator/src/main/kotlin/com/yonatankarp/iterator/list/ItemType.kt
@@ -1,0 +1,15 @@
+package com.yonatankarp.iterator.list
+
+/**
+ * Enumerates the types of items that can be found in a
+ * [TreasureChest].
+ */
+enum class ItemType {
+    ANY,
+    POTION,
+    RING,
+    WEAPON,
+    ;
+
+    override fun toString() = name.lowercase()
+}

--- a/iterator/src/main/kotlin/com/yonatankarp/iterator/list/TreasureChest.kt
+++ b/iterator/src/main/kotlin/com/yonatankarp/iterator/list/TreasureChest.kt
@@ -1,0 +1,33 @@
+package com.yonatankarp.iterator.list
+
+/**
+ * A collection of [Item] objects that supports iteration filtered
+ * by [ItemType].
+ */
+class TreasureChest {
+    private val items: List<Item> =
+        listOf(
+            Item(ItemType.POTION, "Potion of courage"),
+            Item(ItemType.RING, "Ring of shadows"),
+            Item(ItemType.POTION, "Potion of wisdom"),
+            Item(ItemType.POTION, "Potion of blood"),
+            Item(ItemType.WEAPON, "Sword of silver +1"),
+            Item(ItemType.POTION, "Potion of rust"),
+            Item(ItemType.POTION, "Potion of healing"),
+            Item(ItemType.RING, "Ring of armor"),
+            Item(ItemType.WEAPON, "Steel halberd"),
+            Item(ItemType.WEAPON, "Dagger of poison"),
+        )
+
+    /**
+     * Returns an iterator over items of the given [itemType].
+     * Pass [ItemType.ANY] to iterate over all items.
+     */
+    fun iterator(itemType: ItemType): Iterator<Item> =
+        TreasureChestItemIterator(items, itemType)
+
+    /**
+     * Returns a defensive copy of all items in the chest.
+     */
+    fun getItems(): List<Item> = items.toList()
+}

--- a/iterator/src/main/kotlin/com/yonatankarp/iterator/list/TreasureChestItemIterator.kt
+++ b/iterator/src/main/kotlin/com/yonatankarp/iterator/list/TreasureChestItemIterator.kt
@@ -1,0 +1,37 @@
+package com.yonatankarp.iterator.list
+
+/**
+ * An [Iterator] over [Item] objects filtered by [ItemType].
+ *
+ * When the type is [ItemType.ANY], every item is returned.
+ *
+ * @property items the full list of items to iterate over
+ * @property type the item type filter
+ */
+internal class TreasureChestItemIterator(
+    private val items: List<Item>,
+    private val type: ItemType,
+) : Iterator<Item> {
+    private var idx = -1
+
+    override fun hasNext(): Boolean = findNextIdx() != -1
+
+    override fun next(): Item {
+        idx = findNextIdx()
+        check(idx != -1) { "No more items" }
+        return items[idx]
+    }
+
+    private fun findNextIdx(): Int {
+        var tempIdx = idx
+        while (true) {
+            tempIdx++
+            if (tempIdx >= items.size) {
+                return -1
+            }
+            if (type == ItemType.ANY || items[tempIdx].type == type) {
+                return tempIdx
+            }
+        }
+    }
+}

--- a/iterator/src/test/kotlin/com/yonatankarp/iterator/AppTest.kt
+++ b/iterator/src/test/kotlin/com/yonatankarp/iterator/AppTest.kt
@@ -1,0 +1,10 @@
+package com.yonatankarp.iterator
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+internal class AppTest {
+    @Test
+    fun `should execute application without exception`() =
+        assertDoesNotThrow { main() }
+}

--- a/iterator/src/test/kotlin/com/yonatankarp/iterator/bst/BstIteratorTest.kt
+++ b/iterator/src/test/kotlin/com/yonatankarp/iterator/bst/BstIteratorTest.kt
@@ -1,0 +1,68 @@
+package com.yonatankarp.iterator.bst
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.api.assertThrows
+
+@TestInstance(Lifecycle.PER_CLASS)
+internal class BstIteratorTest {
+    private lateinit var nonEmptyRoot: TreeNode<Int>
+
+    @BeforeAll
+    fun createTrees() {
+        nonEmptyRoot =
+            TreeNode(5).apply {
+                insert(3)
+                insert(7)
+                insert(1)
+                insert(4)
+                insert(6)
+            }
+    }
+
+    @Test
+    fun `should throw NoSuchElementException when calling next on empty tree`() {
+        val iter = BstIterator<Int>(null)
+        assertThrows<NoSuchElementException> { iter.next() }
+    }
+
+    @Test
+    fun `should traverse entire populated tree in order`() {
+        // Given
+        val iter = BstIterator(nonEmptyRoot)
+        val expected = listOf(1, 3, 4, 5, 6, 7)
+
+        // When
+        val result = iter.asSequence().map { it.value }.toList()
+
+        // Then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should return false for hasNext on empty tree`() =
+        assertFalse(BstIterator<Int>(null).hasNext())
+
+    @Test
+    fun `should return true for hasNext on populated tree`() =
+        assertTrue(BstIterator(nonEmptyRoot).hasNext())
+
+    @Test
+    fun `should alternate hasNext and next over entire tree`() {
+        // Given
+        val iter = BstIterator(nonEmptyRoot)
+        val expected = listOf(1, 3, 4, 5, 6, 7)
+
+        // When / Then
+        expected.forEach { expectedValue ->
+            assertTrue(iter.hasNext())
+            assertEquals(expectedValue, iter.next().value)
+        }
+        assertFalse(iter.hasNext())
+    }
+}

--- a/iterator/src/test/kotlin/com/yonatankarp/iterator/list/TreasureChestTest.kt
+++ b/iterator/src/test/kotlin/com/yonatankarp/iterator/list/TreasureChestTest.kt
@@ -1,0 +1,82 @@
+package com.yonatankarp.iterator.list
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class TreasureChestTest {
+    @ParameterizedTest
+    @MethodSource("dataProvider")
+    fun `should find expected item via iterator`(expectedItem: Item) {
+        // Given
+        val chest = TreasureChest()
+        val iterator = chest.iterator(expectedItem.type)
+
+        // When
+        val found = iterator.asSequence().any { it.toString() == expectedItem.toString() }
+
+        // Then
+        if (!found) {
+            fail<Unit>(
+                "Expected to find item [$expectedItem] " +
+                    "using iterator, but we didn't.",
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataProvider")
+    fun `should find expected item via getItems`(expectedItem: Item) {
+        // Given
+        val chest = TreasureChest()
+        val items = chest.getItems()
+
+        // When / Then
+        assertNotNull(items)
+        val found =
+            items.any {
+                it.type == expectedItem.type &&
+                    it.toString() == expectedItem.toString()
+            }
+        if (!found) {
+            fail<Unit>(
+                "Expected to find item [$expectedItem] " +
+                    "in the item list, but we didn't.",
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataProvider")
+    fun `iterator should only return items of requested type`(
+        expectedItem: Item,
+    ) {
+        // Given
+        val chest = TreasureChest()
+        val iterator = chest.iterator(expectedItem.type)
+
+        // When / Then
+        iterator.forEach { item ->
+            assertEquals(expectedItem.type, item.type)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun dataProvider() =
+            listOf(
+                arrayOf(Item(ItemType.POTION, "Potion of courage")),
+                arrayOf(Item(ItemType.RING, "Ring of shadows")),
+                arrayOf(Item(ItemType.POTION, "Potion of wisdom")),
+                arrayOf(Item(ItemType.POTION, "Potion of blood")),
+                arrayOf(Item(ItemType.WEAPON, "Sword of silver +1")),
+                arrayOf(Item(ItemType.POTION, "Potion of rust")),
+                arrayOf(Item(ItemType.POTION, "Potion of healing")),
+                arrayOf(Item(ItemType.RING, "Ring of armor")),
+                arrayOf(Item(ItemType.WEAPON, "Steel halberd")),
+                arrayOf(Item(ItemType.WEAPON, "Dagger of poison")),
+            )
+    }
+}


### PR DESCRIPTION
Add Iterator design pattern implementation

Closes #406

- Ports the Iterator pattern from the Java reference repo to idiomatic Kotlin
- List-based: `TreasureChest` with `TreasureChestItemIterator` implementing `Iterator<Item>`
- BST-based: `TreeNode` with `BstIterator` providing in-order traversal via `ArrayDeque` stack
- `Item` data class, `ItemType` enum with alphabetical entries
- Tests cover both iterator variants with parameterized tests
- README with Mermaid class diagram and programmatic example