### PR TITLE
Enable tags display on GitHub Pages

### DIFF
--- a/abstract-factory/README.md
+++ b/abstract-factory/README.md
@@ -2,7 +2,8 @@
 title: Abstract Factory
 category: Creational
 language: en
-tag:
+tags:
+  - Creational
   - Abstraction
   - Decoupling
   - Gang of Four

--- a/adapter/README.md
+++ b/adapter/README.md
@@ -2,7 +2,8 @@
 title: Adapter
 category: Structural
 language: en
-tag:
+tags:
+  - Structural
   - Compatibility
   - Decoupling
   - Gang of Four

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -2,7 +2,8 @@
 title: Bridge
 category: Structural
 language: en
-tag:
+tags:
+  - Structural
   - Abstraction
   - Decoupling
   - Extensibility

--- a/builder/README.md
+++ b/builder/README.md
@@ -2,7 +2,8 @@
 title: Builder
 category: Creational
 language: en
-tag:
+tags:
+  - Creational
   - Gang of Four
   - Instantiation
   - Object composition

--- a/chain-of-responsibility/README.md
+++ b/chain-of-responsibility/README.md
@@ -2,7 +2,8 @@
 title: Chain of Responsibility
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Decoupling
   - Event-driven
   - Gang of Four

--- a/command/README.md
+++ b/command/README.md
@@ -2,7 +2,8 @@
 title: Command
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Decoupling
   - Extensibility
   - Gang of Four

--- a/composite/README.md
+++ b/composite/README.md
@@ -2,7 +2,8 @@
 title: Composite
 category: Structural
 language: en
-tag:
+tags:
+  - Structural
   - Decoupling
   - Gang of Four
   - Object composition

--- a/decorator/README.md
+++ b/decorator/README.md
@@ -2,7 +2,8 @@
 title: Decorator
 category: Structural
 language: en
-tag:
+tags:
+  - Structural
   - Enhancement
   - Extensibility
   - Gang of Four

--- a/facade/README.md
+++ b/facade/README.md
@@ -2,7 +2,8 @@
 title: Facade
 category: Structural
 language: en
-tag:
+tags:
+  - Structural
   - Abstraction
   - API design
   - Code simplification

--- a/factory-method/README.md
+++ b/factory-method/README.md
@@ -2,7 +2,8 @@
 title: Factory Method
 category: Creational
 language: en
-tag:
+tags:
+  - Creational
   - Encapsulation
   - Gang of Four
   - Instantiation

--- a/factory/README.md
+++ b/factory/README.md
@@ -2,7 +2,8 @@
 title: Factory
 category: Creational
 language: en
-tag:
+tags:
+  - Creational
   - Abstraction
   - Encapsulation
   - Gang of Four

--- a/flyweight/README.md
+++ b/flyweight/README.md
@@ -2,7 +2,8 @@
 title: Flyweight
 category: Structural
 language: en
-tag:
+tags:
+  - Structural
   - Gang of Four
   - Memory management
   - Object composition

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -2,7 +2,8 @@
 title: Interpreter
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Abstraction
   - Data transformation
   - Decoupling

--- a/iterator/README.md
+++ b/iterator/README.md
@@ -2,7 +2,8 @@
 title: Iterator
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Data access
   - Data transformation
   - Decoupling

--- a/mediator/README.md
+++ b/mediator/README.md
@@ -2,7 +2,8 @@
 title: Mediator
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Decoupling
   - Gang of Four
   - Messaging

--- a/memento/README.md
+++ b/memento/README.md
@@ -2,7 +2,8 @@
 title: Memento
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Encapsulation
   - Gang of Four
   - State tracking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ markdown_extensions:
 plugins:
   - search
   - same-dir
+  - tags
 
 exclude_docs: |
   **/src/**

--- a/observer/README.md
+++ b/observer/README.md
@@ -2,7 +2,8 @@
 title: Observer
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Decoupling
   - Event-driven
   - Gang of Four

--- a/prototype/README.md
+++ b/prototype/README.md
@@ -2,7 +2,8 @@
 title: Prototype
 category: Creational
 language: en
-tag:
+tags:
+  - Creational
   - Gang of Four
   - Instantiation
   - Object composition

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -2,7 +2,8 @@
 title: Proxy
 category: Structural
 language: en
-tag:
+tags:
+  - Structural
   - Decoupling
   - Encapsulation
   - Gang of Four

--- a/singleton/README.md
+++ b/singleton/README.md
@@ -2,7 +2,8 @@
 title: Singleton
 category: Creational
 language: en
-tag:
+tags:
+  - Creational
   - Gang of Four
   - Instantiation
   - Lazy initialization

--- a/state/README.md
+++ b/state/README.md
@@ -2,7 +2,8 @@
 title: State
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Decoupling
   - Gang of Four
   - State tracking

--- a/strategy/README.md
+++ b/strategy/README.md
@@ -2,7 +2,8 @@
 title: Strategy
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Decoupling
   - Extensibility
   - Gang of Four

--- a/template-method/README.md
+++ b/template-method/README.md
@@ -2,7 +2,8 @@
 title: Template Method
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Abstraction
   - Code simplification
   - Extensibility

--- a/visitor/README.md
+++ b/visitor/README.md
@@ -2,7 +2,8 @@
 title: Visitor
 category: Behavioral
 language: en
-tag:
+tags:
+  - Behavioral
   - Gang of Four
 ---
 


### PR DESCRIPTION
## Enable tags display on GitHub Pages

Adds visible tag metadata to each pattern page on the documentation site.

### Main changes

- Enable Material's `tags` plugin in `mkdocs.yml`
- Rename frontmatter key from `tag` (singular) to `tags` (Material convention) across all 24 pattern READMEs
- Add each pattern's category (Creational, Structural, Behavioral) as a tag so it renders visibly on the page

### Notes

Tags are displayed but not yet clickable — Material's free version doesn't support linked tags without a deprecated config option. This can be revisited later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design pattern documentation metadata to support improved categorization and tagging functionality.

* **Chores**
  * Enhanced documentation build configuration to enable tag-based organization and filtering of design patterns across all pattern guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->