### PR TITLE
Move tags below pattern title

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,9 @@ plugins:
   - same-dir
   - tags
 
+extra_css:
+  - stylesheets/tags.css
+
 exclude_docs: |
   **/src/**
   **/build/**

--- a/stylesheets/tags.css
+++ b/stylesheets/tags.css
@@ -1,0 +1,15 @@
+/* Move tags below the first heading */
+.md-content__inner {
+  display: flex;
+  flex-direction: column;
+}
+.md-content__inner > h1 {
+  order: 0;
+}
+.md-content__inner > .md-tags {
+  order: 1;
+  margin-bottom: 1em;
+}
+.md-content__inner > *:not(.md-tags):not(h1) {
+  order: 2;
+}


### PR DESCRIPTION
## Move tags below pattern title

Material's tags plugin renders tags above the page title by default. This adds a small CSS override using flexbox ordering to move them below the `h1` heading, which reads more naturally.

### Main changes

- Add `stylesheets/tags.css` with flexbox reordering for `.md-tags` and `h1`
- Reference the stylesheet in `mkdocs.yml` via `extra_css`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Added custom CSS styling that adjusts the layout and positioning of page elements, including headings and tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->