### PR TITLE
Fix tags CSS breaking heading order on pages

### DIFF
--- a/stylesheets/tags.css
+++ b/stylesheets/tags.css
@@ -3,13 +3,13 @@
   display: flex;
   flex-direction: column;
 }
-.md-content__inner > h1 {
+.md-content__inner > h1:first-child {
   order: 0;
 }
 .md-content__inner > .md-tags {
   order: 1;
   margin-bottom: 1em;
 }
-.md-content__inner > *:not(.md-tags):not(h1) {
+.md-content__inner > *:not(.md-tags):not(h1:first-child) {
   order: 2;
 }


### PR DESCRIPTION
## Summary
- Enabled tags display on GitHub Pages pattern pages via mkdocs.yml
- Added custom CSS to position tags below the page title
- Fixed CSS flex ordering that caused all `h1` elements to float to the top of the page — now only targets `h1:first-child`

## Test plan
- [ ] Verify homepage headings render in correct document order
- [ ] Verify pattern pages still show tags below the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved styling precision for element ordering in content areas, ensuring better layout consistency for headings and related content elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->