### PR TITLE
Use shared markdown lint config

### DIFF
--- a/.github/workflows/markdown_linter.yml
+++ b/.github/workflows/markdown_linter.yml
@@ -9,26 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Find changed READMEs
-        id: changed
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.sha }}
-        run: |
-          files=$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA" "$HEAD_SHA" -- '**/README.md' | tr '\n' ' ')
-          echo "files=$files" >> "$GITHUB_OUTPUT"
-
-      - name: Lint READMEs
-        if: steps.changed.outputs.files != ''
-        uses: avto-dev/markdown-lint@v1
-        with:
-          config: './config/markdown-lint/rules.json'
-          args: ${{ steps.changed.outputs.files }}
+  linters:
+    uses: yonatankarp/github-actions/.github/workflows/linters.yml@v2
+    with:
+      check_style: false

--- a/config/markdown-lint/rules.json
+++ b/config/markdown-lint/rules.json
@@ -1,7 +1,0 @@
-{
-  "MD013": {
-    "line_length": 80,
-    "code_block_line_length": 120,
-    "tables": false
-  }
-}


### PR DESCRIPTION
## Summary
- replace the custom markdown-lint workflow body with the shared github-actions linter workflow
- disable style checks so this workflow keeps its markdown-only scope
- remove the duplicate local markdown-lint rules copy

## Validation
- parsed workflow YAML locally
- verified no remaining references to the deleted config path or direct avto-dev markdown-lint action